### PR TITLE
Fix broken link to echo workloads doc

### DIFF
--- a/doc/02-echo/index.md
+++ b/doc/02-echo/index.md
@@ -274,7 +274,7 @@ messages.
 
 ## Echo? Echo!
 
-The [Echo Workload](doc/workloads.md#workload-echo) defines a single kind of
+The [Echo Workload](../workloads.md#workload-echo) defines a single kind of
 RPC request: clients send `type: echo` messages with an `echo: <some-string>`
 field, and expect `type: echo_ok` responses with that same `echo:
 <some-string>` back.

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -49,7 +49,7 @@ node can use a monotonically increasing integer as their source of message IDs.
 
 Each message has additional keys, depending on what kind of message it is. For
 example, here is a read request from the `lin_kv` workload, which asks for the
-current value of key `5`:
+current value of key `3`:
 
 ```json
 {


### PR DESCRIPTION
- Link to the echo workloads documentation was broken
- Payload didn't match accompanying text in protocol description