### PR TITLE
core: allow to specify argument for a binary

### DIFF
--- a/src/maelstrom/core.clj
+++ b/src/maelstrom/core.clj
@@ -213,12 +213,21 @@
                                 :dist (:latency-dist o)})
                (dissoc :latency-dist)))))
 
+(defn add-args
+  "Adds non-option arguments as :args into parsed options map. :args value is
+  used as list of arguments for the binary which runs a node."
+  [parsed]
+  (let [a (:arguments parsed)
+        o (:options parsed)]
+    (assoc parsed :options (assoc o :args a))))
+
 (defn opt-fn
   "Post-processes the parsed CLI options structure."
   [parsed]
   (-> parsed
       parse-latency
       parse-node-count
+      add-args
       cli/test-opt-fn))
 
 (defn -main


### PR DESCRIPTION
It's possible to pass arguments for a binary which runs a node in
the db/db function, but it's not possible to specify them when running
maelstrom from command line. Parse command line for binary arguments
and add them to the list of options.