### PR TITLE
04-crdt.md Fix typo

### DIFF
--- a/doc/04-crdts/01-g-set.md
+++ b/doc/04-crdts/01-g-set.md
@@ -33,7 +33,6 @@ keep track of a list of tasks we'd like to run once the node starts, and, once w
 
 ```rb
   def initialize
-    def initialize
     @node_id = nil
     @node_ids = nil
     @next_msg_id = 0


### PR DESCRIPTION
Remove an extra `def initialize` line that seemed to only have been there by mistake