### PR TITLE
Fix typos, Fix 'consistency-levels' to 'consistency-models', Add missing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ network topologies, latency distributions, and faults like network partitions.
 Maelstrom also offers [simulated services](/doc/services.md) that you can use
 to build more complex systems.
 
-It's built for testing toy systems, but don't let that fool you: Maelstrom's
-reasonably fast and can handle simulated clusters of 25+ nodes. On a a 48-way
+It's built for testing toy systems, but don't let that fool you: Maelstrom is
+reasonably fast and can handle simulated clusters of 25+ nodes. On a 48-way
 Xeon, it can use 94% of all cores, pushing upwards of 60,000 network
 messages/sec.
 

--- a/doc/03-broadcast/01-broadcast.md
+++ b/doc/03-broadcast/01-broadcast.md
@@ -519,7 +519,7 @@ traffic. Let's take a look at `messages.svg` to see what's going on:
 
 Aha! We've constructed an *infinite loop*: when one server receives a message,
 it tells its neighbors, who promptly turn around and tell *their* neighbors,
-and the message richochets around the network forever, amplified by a factor of
+and the message ricochets around the network forever, amplified by a factor of
 `neighbors.count` at each step. We should avoid broadcasting a message if we
 already have it.
 

--- a/doc/04-crdts/02-counters.md
+++ b/doc/04-crdts/02-counters.md
@@ -277,5 +277,5 @@ Everything looks good! ヽ(‘ー`)ノ
 
 It is! We've successfully built an AP counter service!
 
-In the next chapter, we'll build a transactional key-value store on top of
+In the [next chapter](/doc/05-datomic/01-single-node.md), we'll build a transactional key-value store on top of
 existing Maelstrom services.

--- a/doc/05-datomic/01-single-node.md
+++ b/doc/05-datomic/01-single-node.md
@@ -13,7 +13,7 @@ lists or appends.
 The workload we'll use for this chapter is called
 [txn-list-append](/doc/workloads.md#workload-txn-list-append). Our servers need
 to support a single RPC type `txn`, which takes an incomplete transaction (e.g.
-one where reads have no values) transaction to execute, and returns the
+one where reads have no values) to execute, and returns the
 completed version of that transaction (i.e. with reads filled in).
 
 ```js
@@ -80,7 +80,7 @@ Transactor.new.node.main!
 ```
 
 ```sh
-$ chmod +x datomic.rb`
+$ chmod +x datomic.rb
 ```
 
 Now, let's fire up Maelstrom, and see what kind of messages we get from our workload.
@@ -244,7 +244,8 @@ end
 ```
 
 ```clj
-./maelstrom test -w txn-list-append --bin datomic.rb --time-limit 10 --node-count 1...
+./maelstrom test -w txn-list-append --bin datomic.rb --time-limit 10 --node-count 1
+...
 Everything looks good! ヽ(‘ー`)ノ
 ```
 

--- a/doc/05-datomic/03-persistent-trees.md
+++ b/doc/05-datomic/03-persistent-trees.md
@@ -196,7 +196,7 @@ class State
 And when it comes time to execute a transaction, we'll make sure to thread that
 node and idgen into the Map loader. We also need to `save!` the map before
 trying to CaS it to a new value: we don't want to create a map with thunks that
-noboby else can read.
+nobody else can read.
 
 ```rb
   def transact!(txn)

--- a/doc/05-datomic/04-optimization.md
+++ b/doc/05-datomic/04-optimization.md
@@ -40,7 +40,7 @@ This plot, from `elle/G-single-realtime/0.svg`, shows the anomaly that my
 particular test found--yours may vary. Each segmented rectangle is a single
 transaction: `a 9 2` means "append 2 to key 9" and `r 9 [2]` means "read key
 9's value as [2]". Edges show dependencies between transactions: `rt` means
-thatone transaction completed before another began, `wr` means that one
+that one transaction completed before another began, `wr` means that one
 transaction wrote something another observed, and `rw` means that one
 transaction observed a state overwritten by a later transaction.
 

--- a/doc/06-raft/02-leader-election.md
+++ b/doc/06-raft/02-leader-election.md
@@ -272,7 +272,7 @@ empty (or in this case, trivial) log is enough to get leader election going.
 ## Requesting Votes
 
 When we become a candidate, we need to broadcast a request for votes to all
-other nodes in the cluster, and accumulate reponses as they arrive. Let's
+other nodes in the cluster, and accumulate responses as they arrive. Let's
 modify our `Node` class to include a broadcast rpc method, which does just
 that:
 

--- a/doc/workloads.md
+++ b/doc/workloads.md
@@ -380,8 +380,8 @@ unchanged.
 Unlike lin-kv, nonexistent keys should be returned as `null`. Lists are
 implicitly created on first append.
 
-This workload can check many kinds of consistency levels. See the
-`--consistency-level` CLI option for details. 
+This workload can check many kinds of consistency models. See the
+`--consistency-models` CLI option for details. 
 
 ### RPC: Txn! 
 

--- a/src/maelstrom/workload/txn_list_append.clj
+++ b/src/maelstrom/workload/txn_list_append.clj
@@ -31,8 +31,8 @@
   Unlike lin-kv, nonexistent keys should be returned as `null`. Lists are
   implicitly created on first append.
 
-  This workload can check many kinds of consistency levels. See the
-  `--consistency-level` CLI option for details."
+  This workload can check many kinds of consistency models. See the
+  `--consistency-models` CLI option for details."
   (:refer-clojure :exclude [read])
   (:require [elle.core :as elle]
             [maelstrom [client :as c]


### PR DESCRIPTION
Fixed some typos;
Fixed a case where the documentation incorrectly refered to the `--consistency-models` flag as `--consistency-levels`;
Added a link between CRDTs and Datomic to ease reading.

(Great docs by the way!)