### PR TITLE
Implement Node in Go

### DIFF
--- a/demo/go/cmd/maelstrom-echo/main.go
+++ b/demo/go/cmd/maelstrom-echo/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+
+	maelstrom "github.com/jepsen-io/maelstrom/demo/go"
+)
+
+func main() {
+	n := maelstrom.NewNode()
+
+	// Register a handler for the "echo" message that responds with an "echo_ok".
+	n.Handle("echo", func(msg maelstrom.Message) error {
+		// Unmarshal the message body as an loosely-typed map.
+		var body map[string]any
+		if err := json.Unmarshal(msg.Body, &body); err != nil {
+			return err
+		}
+
+		// Update the message type.
+		body["type"] = "echo_ok"
+
+		// Echo the original message back with the updated message type.
+		return n.Reply(msg, body)
+	})
+
+	// Execute the node's message loop. This will run until STDIN is closed.
+	if err := n.Run(); err != nil {
+		log.Printf("ERROR: %s", err)
+		os.Exit(1)
+	}
+}

--- a/demo/go/go.mod
+++ b/demo/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/jepsen-io/maelstrom/demo/go
+
+go 1.19

--- a/demo/go/node.go
+++ b/demo/go/node.go
@@ -1,0 +1,371 @@
+package maelstrom
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sync"
+)
+
+// Node represents a single node in the network.
+type Node struct {
+	mu sync.Mutex
+	wg sync.WaitGroup
+
+	id        string
+	nodeIDs   []string
+	nextMsgID int
+
+	handlers  map[string]HandlerFunc
+	callbacks map[int]HandlerFunc
+
+	// Stdin is for reading messages in from the Maelstrom network.
+	Stdin io.Reader
+
+	// Stdin is for writing messages out to the Maelstrom network.
+	Stdout io.Writer
+}
+
+// NewNode returns a new instance of Node connected to STDIN/STDOUT.
+func NewNode() *Node {
+	return &Node{
+		handlers:  make(map[string]HandlerFunc),
+		callbacks: make(map[int]HandlerFunc),
+
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+	}
+}
+
+// ID returns the identifier for this node.
+// Only valid after "init" message has been received.
+func (n *Node) ID() string {
+	return n.id
+}
+
+// NodeIDs returns a list of all node IDs in the cluster. This list include the
+// local node ID and is the same order across all nodes. Only valid after "init"
+// message has been received.
+func (n *Node) NodeIDs() []string {
+	return n.nodeIDs
+}
+
+// Handle registers a message handler for a given message type. Will panic if
+// registering multiple handlers for the same message type.
+func (n *Node) Handle(typ string, fn HandlerFunc) {
+	if _, ok := n.handlers[typ]; ok {
+		panic(fmt.Sprintf("duplicate message handler for %q message type", typ))
+	}
+	n.handlers[typ] = fn
+}
+
+// Run executes the main event handling loop. It reads in messages from STDIN
+// and delegates them to the appropriate registered handler. This should be
+// the last function executed by main().
+func (n *Node) Run() error {
+	scanner := bufio.NewScanner(n.Stdin)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+
+		// Parse next line from STDIN as a JSON-formatted message.
+		var msg Message
+		if err := json.Unmarshal(line, &msg); err != nil {
+			return fmt.Errorf("unmarshal message: %w", err)
+		}
+
+		var body MessageBody
+		if err := json.Unmarshal(msg.Body, &body); err != nil {
+			return fmt.Errorf("unmarshal message body: %w", err)
+		}
+		log.Printf("Received %s", msg)
+
+		// The init message has special handling. It is processed synchronously
+		// to avoid race conditions and the node handles the reply itself.
+		if body.Type == "init" {
+			if err := n.handleInit(msg); err != nil {
+				return fmt.Errorf("handle init: %w", err)
+			}
+			continue
+		}
+
+		// What handler should we use for this message?
+		var h HandlerFunc
+		if body.InReplyTo != 0 {
+			// Extract callback, if replying to a previous message.
+			n.mu.Lock()
+			h = n.callbacks[body.InReplyTo]
+			delete(n.callbacks, body.InReplyTo)
+			n.mu.Unlock()
+
+			// If no callback exists, just log a message and skip.
+			if h == nil {
+				log.Printf("Ignoring reply to %d with no callback", body.InReplyTo)
+				continue
+			}
+		} else {
+			// If this is not a callback, ensure that a handler is registered.
+			h = n.handlers[body.Type]
+			if h == nil {
+				return fmt.Errorf("No handler for %s", line)
+			}
+		}
+
+		// Handle message in a separate goroutine.
+		n.wg.Add(1)
+		go func() {
+			defer n.wg.Done()
+			n.handle(h, msg)
+		}()
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	// Wait for all in-flight handlers to complete.
+	n.wg.Wait()
+
+	return nil
+}
+
+// handle sends msg to a handler function. Sends an RPC error if an error is returned.
+func (n *Node) handle(h HandlerFunc, msg Message) {
+	if err := h(msg); err != nil {
+		switch err := err.(type) {
+		case *RPCError:
+			if err := n.Reply(msg, err); err != nil {
+				log.Printf("reply error: %s", err)
+			}
+		default:
+			log.Printf("Exception handling %#v:\n%s", msg, err)
+			if err := n.Reply(msg, NewRPCError(Crash, err.Error())); err != nil {
+				log.Printf("reply error: %s", err)
+			}
+		}
+	}
+}
+
+func (n *Node) handleInit(msg Message) error {
+	var body InitMessageBody
+	if err := json.Unmarshal(msg.Body, &body); err != nil {
+		return fmt.Errorf("unmarshal init message body: %w", err)
+	}
+	n.id = body.NodeID
+	n.nodeIDs = body.NodeIDs
+
+	// Delegate to application initialization handler, if specified.
+	if h := n.handlers["init"]; h != nil {
+		if err := h(msg); err != nil {
+			return err
+		}
+	}
+
+	// Send back a response that the node has been initialized.
+	log.Printf("Node %s initialized", n.id)
+	return n.Reply(msg, MessageBody{Type: "init_ok"})
+}
+
+// Reply replies to a request with a response body.
+func (n *Node) Reply(req Message, body any) error {
+	// Extract the message ID from the original message.
+	var reqBody MessageBody
+	if err := json.Unmarshal(req.Body, &reqBody); err != nil {
+		return err
+	}
+
+	// We have to marshal/unmarshal to inject our reply message ID.
+	b := make(map[string]any)
+	if buf, err := json.Marshal(body); err != nil {
+		return err
+	} else if err := json.Unmarshal(buf, &b); err != nil {
+		return err
+	}
+	b["in_reply_to"] = reqBody.MsgID
+
+	return n.Send(req.Src, b)
+}
+
+// Send sends a message body to a given destination node.
+func (n *Node) Send(dest string, body any) error {
+	bodyJSON, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	buf, err := json.Marshal(Message{
+		Src:  n.id,
+		Dest: dest,
+		Body: bodyJSON,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Synchronize access to STDOUT.
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	log.Printf("Sent %s", buf)
+
+	if _, err = n.Stdout.Write(buf); err != nil {
+		return err
+	}
+	_, err = n.Stdout.Write([]byte{'\n'})
+	return err
+}
+
+// Broadcast sends a message to all other nodes.
+func (n *Node) Broadcast(body any) error {
+	for _, id := range n.nodeIDs {
+		if id == n.id {
+			continue
+		}
+		if err := n.Send(id, body); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// RPC send an async RPC request. Handler invoked when response message received.
+func (n *Node) RPC(dest string, body any, handler HandlerFunc) error {
+	n.mu.Lock()
+
+	// Generate a unique message ID.
+	n.nextMsgID++
+	msgID := n.nextMsgID
+
+	// Register a handler for our callback.
+	n.callbacks[msgID] = handler
+
+	n.mu.Unlock()
+
+	// We have to marshal/unmarshal to inject our message ID.
+	b := make(map[string]any)
+	if buf, err := json.Marshal(body); err != nil {
+		return err
+	} else if err := json.Unmarshal(buf, &b); err != nil {
+		return err
+	}
+	b["msg_id"] = msgID
+
+	return n.Send(dest, b)
+}
+
+// BroadcastRPC sends an RPC message to all other nodes.
+func (n *Node) BroadcastRPC(body any, handler HandlerFunc) error {
+	for _, id := range n.nodeIDs {
+		if id == n.id {
+			continue
+		}
+		if err := n.RPC(id, body, handler); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Message represents a message sent from Src node to Dest node.
+// The body is stored as unparsed JSON so the handler can parse it itself.
+type Message struct {
+	Src  string          `json:"src,omitempty"`
+	Dest string          `json:"dest,omitempty"`
+	Body json.RawMessage `json:"body,omitempty"`
+}
+
+// MessageBody represents the reserved keys for a message body.
+type MessageBody struct {
+	Type      string `json:"type,omitempty"`
+	MsgID     int    `json:"msg_id,omitempty"`
+	InReplyTo int    `json:"in_reply_to,omitempty"`
+}
+
+// InitMessageBody represents the message body for the "init" message.
+type InitMessageBody struct {
+	MessageBody
+	NodeID  string   `json:"node_id,omitempty"`
+	NodeIDs []string `json:"node_ids,omitempty"`
+}
+
+// HandlerFunc is the function signature for a message handler.
+type HandlerFunc func(msg Message) error
+
+// RPC error code constants.
+const (
+	Timeout                = 0
+	NotSupported           = 10
+	TemporarilyUnavailable = 11
+	MalformedRequest       = 12
+	Crash                  = 13
+	Abort                  = 14
+	KeyDoesNotExist        = 20
+	KeyAlreadyExists       = 21
+	PreconditionFailed     = 22
+	TxnConflict            = 30
+)
+
+// ErrorCodeText returns the text representation of an error code.
+func ErrorCodeText(code int) string {
+	switch code {
+	case Timeout:
+		return "Timeout"
+	case NotSupported:
+		return "NotSupported"
+	case TemporarilyUnavailable:
+		return "TemporarilyUnavailable"
+	case MalformedRequest:
+		return "MalformedRequest"
+	case Crash:
+		return "Crash"
+	case Abort:
+		return "Abort"
+	case KeyDoesNotExist:
+		return "KeyDoesNotExist"
+	case KeyAlreadyExists:
+		return "KeyAlreadyExists"
+	case PreconditionFailed:
+		return "PreconditionFailed"
+	case TxnConflict:
+		return "TxnConflict"
+	default:
+		return fmt.Sprintf("ErrorCode<%d>", code)
+	}
+}
+
+// RPCError represents a Maelstrom RPC error.
+type RPCError struct {
+	code int
+	text string
+}
+
+// NewRPCError returns a new instance of RPCError.
+func NewRPCError(code int, text string) *RPCError {
+	return &RPCError{
+		code: code,
+		text: text,
+	}
+}
+
+// Error returns a string-formatted error message.
+func (e *RPCError) Error() string {
+	return fmt.Sprintf("RPCError(%s, %q)", ErrorCodeText(e.code), e.text)
+}
+
+// MarshalJSON marshals the error into JSON format.
+func (e *RPCError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rpcErrorJSON{
+		Type: "error",
+		Code: e.code,
+		Text: e.text,
+	})
+}
+
+// rpcErrorJSON is a struct for marshaling an RPCError to JSON.
+type rpcErrorJSON struct {
+	Type string `json:"type,omitempty"`
+	Code int    `json:"code,omitempty"`
+	Text string `json:"text,omitempty"`
+}

--- a/demo/go/node_test.go
+++ b/demo/go/node_test.go
@@ -1,0 +1,346 @@
+package maelstrom_test
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	maelstrom "github.com/jepsen-io/maelstrom/demo/go"
+)
+
+func TestNode_Run(t *testing.T) {
+	t.Run("ErrMalformedInputJSON", func(t *testing.T) {
+		var stdout bytes.Buffer
+		n := maelstrom.NewNode()
+		n.Stdin = strings.NewReader("\n")
+		n.Stdout = &stdout
+		if err := n.Run(); err == nil || err.Error() != `unmarshal message: unexpected end of JSON input` {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("ErrMissingHandler", func(t *testing.T) {
+		var stdout bytes.Buffer
+		n := maelstrom.NewNode()
+		n.Stdin = strings.NewReader(`{"dest":"n1", "body":{"type":"echo", "msg_id":1}}` + "\n")
+		n.Stdout = &stdout
+		if err := n.Run(); err == nil || err.Error() != `No handler for {"dest":"n1", "body":{"type":"echo", "msg_id":1}}` {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("ReturnRPCError", func(t *testing.T) {
+		var stdout bytes.Buffer
+		n := maelstrom.NewNode()
+		n.Stdin = strings.NewReader(`{"dest":"n1", "body":{"type":"foo", "msg_id":1000}}` + "\n")
+		n.Stdout = &stdout
+		n.Handle("foo", func(msg maelstrom.Message) error {
+			return maelstrom.NewRPCError(maelstrom.NotSupported, "bad call")
+		})
+		if err := n.Run(); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := stdout.String(), `{"body":{"code":10,"in_reply_to":1000,"text":"bad call","type":"error"}}`+"\n"; got != want {
+			t.Fatalf("stdout=%s, want %s", got, want)
+		}
+	})
+
+	t.Run("ReturnNonRPCError", func(t *testing.T) {
+		var stdout bytes.Buffer
+		n := maelstrom.NewNode()
+		n.Stdin = strings.NewReader(`{"dest":"n1", "body":{"type":"foo", "msg_id":1000}}` + "\n")
+		n.Stdout = &stdout
+		n.Handle("foo", func(msg maelstrom.Message) error {
+			return fmt.Errorf("bad call")
+		})
+		if err := n.Run(); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := stdout.String(), `{"body":{"code":13,"in_reply_to":1000,"text":"bad call","type":"error"}}`+"\n"; got != want {
+			t.Fatalf("stdout=%s, want %s", got, want)
+		}
+	})
+}
+
+// Ensure a node can handle the "init" message.
+func TestNode_Run_Init(t *testing.T) {
+	n, stdin, stdout := newNode(t)
+
+	initialized := make(chan struct{})
+	n.Handle("init", func(msg maelstrom.Message) error {
+		initialized <- struct{}{}
+		return nil
+	})
+
+	// Send "init" message to node.
+	if _, err := stdin.Write([]byte(`{"body":{"type":"init", "msg_id":1, "node_id":"n3", "node_ids":["n1", "n2", "n3"]}}` + "\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure node extracts the ID & cluster membership.
+	select {
+	case <-initialized:
+		if got, want := n.ID(), "n3"; got != want {
+			t.Fatalf("node_id=%q, want %q", got, want)
+		}
+		if got, want := n.NodeIDs(), []string{"n1", "n2", "n3"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("node_ids=%q, want %q", got, want)
+		}
+	}
+
+	// Ensure a correct response was sent back to the network.
+	if line, err := stdout.ReadString('\n'); err != nil {
+		t.Fatal(err)
+	} else if got, want := line, `{"src":"n3","body":{"in_reply_to":1,"type":"init_ok"}}`+"\n"; got != want {
+		t.Fatalf("response=%s, want %s", got, want)
+	}
+}
+
+// Ensure a node can act as an echo server.
+func TestNode_Run_Echo(t *testing.T) {
+	n, stdin, stdout := newNode(t)
+
+	n.Handle("echo", func(msg maelstrom.Message) error {
+		var body map[string]any
+		if err := json.Unmarshal(msg.Body, &body); err != nil {
+			return err
+		}
+		body["type"] = "echo_ok"
+
+		return n.Reply(msg, body)
+	})
+
+	// Initialize node.
+	initNode(t, n, "n1", []string{"n1"}, stdin, stdout)
+
+	// Send echo message.
+	if _, err := stdin.Write([]byte(`{"dest":"n1", "body":{"type":"echo", "msg_id":2}}` + "\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure response is echo'd back.
+	if line, err := stdout.ReadString('\n'); err != nil {
+		t.Fatal(err)
+	} else if got, want := line, `{"src":"n1","body":{"in_reply_to":2,"msg_id":2,"type":"echo_ok"}}`+"\n"; got != want {
+		t.Fatalf("response=%s, want %s", got, want)
+	}
+}
+
+// Ensure a duplicate handler causes a panic.
+func TestNode_Handle(t *testing.T) {
+	t.Run("ErrDuplicate", func(t *testing.T) {
+		n, _, _ := newNode(t)
+		n.Handle("foo", func(msg maelstrom.Message) error { return nil })
+
+		var r any
+		func() {
+			defer func() {
+				r = recover()
+			}()
+			n.Handle("foo", func(msg maelstrom.Message) error { return nil })
+		}()
+
+		if got, want := r, `duplicate message handler for "foo" message type`; got != want {
+			t.Fatalf("recover=%s, want %s", got, want)
+		}
+	})
+}
+
+// Ensure node can broadcast a message to all other nodes.
+func TestNode_Broadcast(t *testing.T) {
+	n, stdin, stdout := newNode(t)
+	initNode(t, n, "n1", []string{"n1", "n2", "n3"}, stdin, stdout)
+
+	// Send RPC call.
+	errorCh := make(chan error)
+	go func() {
+		errorCh <- n.Broadcast(map[string]any{"type": "foo"})
+	}()
+
+	// Ensure messages are sent out.
+	if line, err := stdout.ReadString('\n'); err != nil {
+		t.Fatal(err)
+	} else if got, want := line, `{"src":"n1","dest":"n2","body":{"type":"foo"}}`+"\n"; got != want {
+		t.Fatalf("msg[0]=%s, want %s", got, want)
+	}
+
+	if line, err := stdout.ReadString('\n'); err != nil {
+		t.Fatal(err)
+	} else if got, want := line, `{"src":"n1","dest":"n3","body":{"type":"foo"}}`+"\n"; got != want {
+		t.Fatalf("msg[1]=%s, want %s", got, want)
+	}
+
+	if err := <-errorCh; err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure node can handle a request/response RPC call.
+func TestNode_RPC(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		n, stdin, stdout := newNode(t)
+		initNode(t, n, "n1", []string{"n1", "n2"}, stdin, stdout)
+
+		// Send RPC call.
+		respCh := make(chan maelstrom.Message)
+		errorCh := make(chan error)
+		go func() {
+			if err := n.RPC("n2", map[string]any{"type": "foo", "bar": "baz"}, func(msg maelstrom.Message) error {
+				respCh <- msg
+				return nil
+			}); err != nil {
+				errorCh <- err
+			}
+		}()
+
+		// Ensure RPC request is received by the network.
+		if line, err := stdout.ReadString('\n'); err != nil {
+			t.Fatal(err)
+		} else if got, want := line, `{"src":"n1","dest":"n2","body":{"bar":"baz","msg_id":1,"type":"foo"}}`+"\n"; got != want {
+			t.Fatalf("response=%s, want %s", got, want)
+		}
+
+		// Write response message back to node.
+		if _, err := stdin.Write([]byte(`{"src":"n2", "dest":"n1", "body":{"type":"foo_ok", "msg_id":2, "in_reply_to":1}}` + "\n")); err != nil {
+			t.Fatal(err)
+		}
+
+		// Ensure the callback was handled.
+		select {
+		case msg := <-respCh:
+			if got, want := msg.Src, "n2"; got != want {
+				t.Fatalf("Src=%s, want %s", got, want)
+			}
+			if got, want := msg.Dest, "n1"; got != want {
+				t.Fatalf("Dest=%s, want %s", got, want)
+			}
+			if got, want := string(msg.Body), `{"type":"foo_ok", "msg_id":2, "in_reply_to":1}`; got != want {
+				t.Fatalf("Body=%s, want %s", got, want)
+			}
+		case err := <-errorCh:
+			t.Fatal(err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for RPC response")
+		}
+	})
+
+	t.Run("SkipMissingCallback", func(t *testing.T) {
+		n, stdin, stdout := newNode(t)
+		initNode(t, n, "n1", []string{"n1", "n2"}, stdin, stdout)
+		if _, err := stdin.Write([]byte(`{"src":"n2", "dest":"n1", "body":{"type":"foo_ok", "msg_id":2, "in_reply_to":1000}}` + "\n")); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+// Ensure node can broadcast a request/response RPC call to all nodes.
+func TestNode_BroadcastRPC(t *testing.T) {
+	n, stdin, stdout := newNode(t)
+	initNode(t, n, "n1", []string{"n1", "n2", "n3"}, stdin, stdout)
+
+	// Send RPC call.
+	errorCh := make(chan error)
+	go func() {
+		errorCh <- n.BroadcastRPC(map[string]any{"type": "foo", "bar": "baz"}, func(msg maelstrom.Message) error {
+			return nil
+		})
+	}()
+
+	// Ensure RPC requests are received by the network.
+	if line, err := stdout.ReadString('\n'); err != nil {
+		t.Fatal(err)
+	} else if got, want := line, `{"src":"n1","dest":"n2","body":{"bar":"baz","msg_id":1,"type":"foo"}}`+"\n"; got != want {
+		t.Fatalf("req[0]=%s, want %s", got, want)
+	}
+
+	if line, err := stdout.ReadString('\n'); err != nil {
+		t.Fatal(err)
+	} else if got, want := line, `{"src":"n1","dest":"n3","body":{"bar":"baz","msg_id":2,"type":"foo"}}`+"\n"; got != want {
+		t.Fatalf("req[1]=%s, want %s", got, want)
+	}
+}
+
+func TestErrorCodeText(t *testing.T) {
+	for _, tt := range []struct {
+		code int
+		text string
+	}{
+		{maelstrom.Timeout, "Timeout"},
+		{maelstrom.NotSupported, "NotSupported"},
+		{maelstrom.TemporarilyUnavailable, "TemporarilyUnavailable"},
+		{maelstrom.MalformedRequest, "MalformedRequest"},
+		{maelstrom.Crash, "Crash"},
+		{maelstrom.Abort, "Abort"},
+		{maelstrom.KeyDoesNotExist, "KeyDoesNotExist"},
+		{maelstrom.KeyAlreadyExists, "KeyAlreadyExists"},
+		{maelstrom.PreconditionFailed, "PreconditionFailed"},
+		{maelstrom.TxnConflict, "TxnConflict"},
+		{1000, "ErrorCode<1000>"},
+	} {
+		if got, want := maelstrom.ErrorCodeText(tt.code), tt.text; got != want {
+			t.Errorf("code %d=%s, want %s", tt.code, got, want)
+		}
+	}
+}
+
+func TestRPCError_Error(t *testing.T) {
+	if got, want := maelstrom.NewRPCError(maelstrom.Crash, "foo").Error(), `RPCError(Crash, "foo")`; got != want {
+		t.Fatalf("error=%s, want %s", got, want)
+	}
+}
+
+// newNode initializes a test node and returns streams to read/write messages.
+func newNode(tb testing.TB) (node *maelstrom.Node, stdin io.Writer, stdout *bufio.Reader) {
+	inr, inw := io.Pipe()
+	outr, outw := io.Pipe()
+
+	// Initialize node and set up pipes so the test can read & write.
+	n := maelstrom.NewNode()
+	n.Stdin = inr
+	n.Stdout = outw
+
+	// Start the message loop.
+	errorCh := make(chan error)
+	go func() { errorCh <- n.Run() }()
+
+	// Ensure node stops by the end of the test.
+	tb.Cleanup(func() {
+		if err := inw.Close(); err != nil {
+			tb.Fatalf("closing stdin: %s", err)
+		}
+
+		select {
+		case err := <-errorCh:
+			if err != nil {
+				tb.Fatalf("maelstrom.Node.Run(): %s", err)
+			}
+		case <-time.After(5 * time.Second):
+			tb.Fatalf("timeout waiting for node to stop")
+		}
+	})
+
+	return n, inw, bufio.NewReader(outr)
+}
+
+func initNode(tb testing.TB, n *maelstrom.Node, id string, nodeIDs []string, stdin io.Writer, stdout *bufio.Reader) {
+	tb.Helper()
+
+	nodeIDsStr := `"` + strings.Join(nodeIDs, `","`) + `"`
+	if _, err := stdin.Write([]byte(fmt.Sprintf(`{"body":{"type":"init", "msg_id":1, "node_id":"%s", "node_ids":[%s]}}`+"\n", id, nodeIDsStr))); err != nil {
+		tb.Fatal(err)
+	}
+
+	// Read & verify
+	if line, err := stdout.ReadString('\n'); err != nil {
+		tb.Fatal(err)
+	} else if got, want := line, fmt.Sprintf(`{"src":"%s","body":{"in_reply_to":1,"type":"init_ok"}}`+"\n", id); got != want {
+		tb.Fatalf("init_ok=%s, want %s", got, want)
+	}
+
+}


### PR DESCRIPTION
This pull request translates the Ruby version of `Node` into Go so that folks can integrate it into a Go workflow more easily. It includes a test suite as well as an example `echo` server. It implements message handling, initialization handling, send, reply, broadcast, & RPC.

## Usage

Below is a copy of the `maelstrom-echo` Go program. It instantiates a `Node`, registers an `"echo"` message handler, and then delegates to `maelstrom.Node.Run()` for the remainder of the program.

```go
package main

import (
	"encoding/json"
	"log"
	"os"

	maelstrom "github.com/jepsen-io/maelstrom/demo/go"
)

func main() {
	n := maelstrom.NewNode()

	// Register a handler for the "echo" message that responds with an "echo_ok".
	n.Handle("echo", func(msg maelstrom.Message) error {
		// Unmarshal the message body as an loosely-typed map.
		var body map[string]any
		if err := json.Unmarshal(msg.Body, &body); err != nil {
			return err
		}

		// Update the message type.
		body["type"] = "echo_ok"

		// Echo the original message back with the updated message type.
		return n.Reply(msg, body)
	})

	// Execute the node's message loop. This will run until STDIN is closed.
	if err := n.Run(); err != nil {
		log.Printf("ERROR: %s", err)
		os.Exit(1)
	}
}
```

You can build this by running:

```sh
$ cd demo/go
$ go install ./cmd/maelstrom-echo
```

Then you can pass `maelstrom-echo` as the binary to `maelstrom`.


## API

### Node

```
type Node struct
    Node represents a single node in the network.

func NewNode() *Node
    NewNode returns a new instance of Node connected to STDIN/STDOUT.

func (n *Node) Broadcast(body any) error
    Broadcast sends a message to all other nodes.

func (n *Node) BroadcastRPC(body any, handler HandlerFunc) error
    BroadcastRPC sends an RPC message to all other nodes.

func (n *Node) Handle(typ string, fn HandlerFunc)
    Handle registers a message handler for a given message type. Will panic if
    registering multiple handlers for the same message type.

func (n *Node) ID() string
    ID returns the identifier for this node. Only valid after "init" message has
    been received.

func (n *Node) NodeIDs() []string
    NodeIDs returns a list of all node IDs in the cluster. This list include
    the local node ID and is the same order across all nodes. Only valid after
    "init" message has been received.

func (n *Node) RPC(dest string, body any, handler HandlerFunc) error
    RPC send an async RPC request. Handler invoked when response message received.

func (n *Node) Reply(req Message, body any) error
    Reply replies to a request with a response body.

func (n *Node) Run() error
    Run executes the main event handling loop. It reads in messages from STDIN
    and delegates them to the appropriate registered handler. This should be the
    last function executed by main().

func (n *Node) Send(dest string, body any) error
    Send sends a message body to a given destination node.
```

### Message Handler

```
type HandlerFunc func(msg Message) error
    HandlerFunc is the function signature for a message handler.
```

### Message & Message Body

```
type Message struct {
	Src  string
	Dest string
	Body json.RawMessage
}
    Message represents a message sent from Src node to Dest node. The body is
    stored as unparsed JSON so the handler can parse it itself.

type MessageBody struct {
	Type      string
	MsgID     int
	InReplyTo int
}
```

### RPCError

```
type RPCError struct
    RPCError represents a Maelstrom RPC error.

func NewRPCError(code int, text string) *RPCError
    NewRPCError returns a new instance of RPCError.
```

