### PR TITLE
Refactor Go node implementation

### DIFF
--- a/demo/go/README.md
+++ b/demo/go/README.md
@@ -1,0 +1,20 @@
+maelstrom-go
+============
+
+This is a Go implementation of the Maelstrom Node. This provides basic message
+handling, an event loop, & a client interface to the key/value store. It's a
+good starting point for implementing a Maelstrom node as it helps to avoid a
+lot of boilerplate.
+
+## Usage
+
+Binaries run by `maelstrom` need to be referenced by absolute or relative path.
+The easiest way to use Go with Maelstrom is to `go install` and then specify
+the relative path to the `--bin` flag:
+
+```sh
+$ cd /path/to/maelstrom-echo
+$ go install .
+$ maelstrom test --bin ~/go/bin/maelstrom-echo ...
+```
+

--- a/demo/go/kv.go
+++ b/demo/go/kv.go
@@ -1,0 +1,123 @@
+package maelstrom
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Types of key/value stores.
+const (
+	LinKV = "lin-kv"
+	SeqKV = "seq-kv"
+	LWWKV = "lww-kv"
+)
+
+// KV represents a client to the key/value store service.
+type KV struct {
+	typ  string
+	node *Node
+}
+
+// NewKV returns a new instance a KV client for a node.
+func NewKV(typ string, node *Node) *KV {
+	return &KV{
+		typ:  typ,
+		node: node,
+	}
+}
+
+// NewLinKV returns a client to the linearizable key/value store.
+func NewLinKV(node *Node) *KV { return NewKV(LinKV, node) }
+
+// NewSeqKV returns a client to the sequential key/value store.
+func NewSeqKV(node *Node) *KV { return NewKV(SeqKV, node) }
+
+// NewLWWKV returns a client to the last-write-wins key/value store.
+func NewLWWKV(node *Node) *KV { return NewKV(LWWKV, node) }
+
+// Read returns the value for a given key in the key/value store.
+// Returns an *RPCError error with a KeyDoesNotExist code if the key does not exist.
+func (kv *KV) Read(ctx context.Context, key string) (any, error) {
+	resp, err := kv.node.SyncRPC(ctx, kv.typ, kvReadMessageBody{
+		MessageBody: MessageBody{Type: "read"},
+		Key:         key,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse read_ok specific data in response message.
+	var body kvReadOKMessageBody
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		return nil, err
+	}
+
+	// Convert numbers to integers since that's what maelstrom workloads use.
+	switch v := body.Value.(type) {
+	case float64:
+		return int(v), nil
+	default:
+		return v, nil
+	}
+}
+
+// ReadInt reads the value of a key in the key/value store as an int.
+func (kv *KV) ReadInt(ctx context.Context, key string) (int, error) {
+	v, err := kv.Read(ctx, key)
+	i, _ := v.(int)
+	return i, err
+}
+
+// Write overwrites the value for a given key in the key/value store.
+func (kv *KV) Write(ctx context.Context, key string, value any) error {
+	_, err := kv.node.SyncRPC(ctx, kv.typ, kvWriteMessageBody{
+		MessageBody: MessageBody{Type: "write"},
+		Key:         key,
+		Value:       value,
+	})
+	return err
+}
+
+// CompareAndSwap updates the value for a key if its current value matches the
+// previous value. Creates the key if createIfNotExists is true.
+//
+// Returns an *RPCError with a code of PreconditionFailed if the previous value
+// does not match. Return a code of KeyDoesNotExist if the key did not exist.
+func (kv *KV) CompareAndSwap(ctx context.Context, key string, from, to any, createIfNotExists bool) error {
+	_, err := kv.node.SyncRPC(ctx, kv.typ, kvCASMessageBody{
+		MessageBody:       MessageBody{Type: "cas"},
+		Key:               key,
+		From:              from,
+		To:                to,
+		CreateIfNotExists: createIfNotExists,
+	})
+	return err
+}
+
+// kvReadMessageBody represents the body for the KV "read" message.
+type kvReadMessageBody struct {
+	MessageBody
+	Key string `json:"key"`
+}
+
+// kvReadOKMessageBody represents the response body for the KV "read_ok" message.
+type kvReadOKMessageBody struct {
+	MessageBody
+	Value any `json:"value"`
+}
+
+// kvWriteMessageBody represents the body for the KV "cas" message.
+type kvWriteMessageBody struct {
+	MessageBody
+	Key   string `json:"key"`
+	Value any    `json:"value"`
+}
+
+// kvCASMessageBody represents the body for the KV "cas" message.
+type kvCASMessageBody struct {
+	MessageBody
+	Key               string `json:"key"`
+	From              any    `json:"from"`
+	To                any    `json:"to"`
+	CreateIfNotExists bool   `json:"create_if_not_exists,omitempty"`
+}

--- a/demo/go/node_test.go
+++ b/demo/go/node_test.go
@@ -3,7 +3,9 @@ package maelstrom_test
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -152,35 +154,6 @@ func TestNode_Handle(t *testing.T) {
 	})
 }
 
-// Ensure node can broadcast a message to all other nodes.
-func TestNode_Broadcast(t *testing.T) {
-	n, stdin, stdout := newNode(t)
-	initNode(t, n, "n1", []string{"n1", "n2", "n3"}, stdin, stdout)
-
-	// Send RPC call.
-	errorCh := make(chan error)
-	go func() {
-		errorCh <- n.Broadcast(map[string]any{"type": "foo"})
-	}()
-
-	// Ensure messages are sent out.
-	if line, err := stdout.ReadString('\n'); err != nil {
-		t.Fatal(err)
-	} else if got, want := line, `{"src":"n1","dest":"n2","body":{"type":"foo"}}`+"\n"; got != want {
-		t.Fatalf("msg[0]=%s, want %s", got, want)
-	}
-
-	if line, err := stdout.ReadString('\n'); err != nil {
-		t.Fatal(err)
-	} else if got, want := line, `{"src":"n1","dest":"n3","body":{"type":"foo"}}`+"\n"; got != want {
-		t.Fatalf("msg[1]=%s, want %s", got, want)
-	}
-
-	if err := <-errorCh; err != nil {
-		t.Fatal(err)
-	}
-}
-
 // Ensure node can handle a request/response RPC call.
 func TestNode_RPC(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
@@ -239,60 +212,125 @@ func TestNode_RPC(t *testing.T) {
 	})
 }
 
-// Ensure node can broadcast a request/response RPC call to all nodes.
-func TestNode_BroadcastRPC(t *testing.T) {
-	n, stdin, stdout := newNode(t)
-	initNode(t, n, "n1", []string{"n1", "n2", "n3"}, stdin, stdout)
+// Ensure node can handle a synchronous request/response RPC call.
+func TestNode_SyncRPC(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		n, stdin, stdout := newNode(t)
+		initNode(t, n, "n1", []string{"n1", "n2"}, stdin, stdout)
 
-	// Send RPC call.
-	errorCh := make(chan error)
-	go func() {
-		errorCh <- n.BroadcastRPC(map[string]any{"type": "foo", "bar": "baz"}, func(msg maelstrom.Message) error {
-			return nil
-		})
-	}()
+		// Send RPC call.
+		respCh := make(chan maelstrom.Message)
+		errorCh := make(chan error)
+		go func() {
+			resp, err := n.SyncRPC(context.Background(), "n2", map[string]any{"type": "foo", "bar": "baz"})
+			if err != nil {
+				errorCh <- err
+			} else {
+				respCh <- resp
+			}
+		}()
 
-	// Ensure RPC requests are received by the network.
-	if line, err := stdout.ReadString('\n'); err != nil {
-		t.Fatal(err)
-	} else if got, want := line, `{"src":"n1","dest":"n2","body":{"bar":"baz","msg_id":1,"type":"foo"}}`+"\n"; got != want {
-		t.Fatalf("req[0]=%s, want %s", got, want)
-	}
-
-	if line, err := stdout.ReadString('\n'); err != nil {
-		t.Fatal(err)
-	} else if got, want := line, `{"src":"n1","dest":"n3","body":{"bar":"baz","msg_id":2,"type":"foo"}}`+"\n"; got != want {
-		t.Fatalf("req[1]=%s, want %s", got, want)
-	}
-}
-
-func TestErrorCodeText(t *testing.T) {
-	for _, tt := range []struct {
-		code int
-		text string
-	}{
-		{maelstrom.Timeout, "Timeout"},
-		{maelstrom.NotSupported, "NotSupported"},
-		{maelstrom.TemporarilyUnavailable, "TemporarilyUnavailable"},
-		{maelstrom.MalformedRequest, "MalformedRequest"},
-		{maelstrom.Crash, "Crash"},
-		{maelstrom.Abort, "Abort"},
-		{maelstrom.KeyDoesNotExist, "KeyDoesNotExist"},
-		{maelstrom.KeyAlreadyExists, "KeyAlreadyExists"},
-		{maelstrom.PreconditionFailed, "PreconditionFailed"},
-		{maelstrom.TxnConflict, "TxnConflict"},
-		{1000, "ErrorCode<1000>"},
-	} {
-		if got, want := maelstrom.ErrorCodeText(tt.code), tt.text; got != want {
-			t.Errorf("code %d=%s, want %s", tt.code, got, want)
+		// Ensure RPC request is received by the network.
+		if line, err := stdout.ReadString('\n'); err != nil {
+			t.Fatal(err)
+		} else if got, want := line, `{"src":"n1","dest":"n2","body":{"bar":"baz","msg_id":1,"type":"foo"}}`+"\n"; got != want {
+			t.Fatalf("response=%s, want %s", got, want)
 		}
-	}
-}
 
-func TestRPCError_Error(t *testing.T) {
-	if got, want := maelstrom.NewRPCError(maelstrom.Crash, "foo").Error(), `RPCError(Crash, "foo")`; got != want {
-		t.Fatalf("error=%s, want %s", got, want)
-	}
+		// Write response message back to node.
+		if _, err := stdin.Write([]byte(`{"src":"n2", "dest":"n1", "body":{"type":"foo_ok", "msg_id":2, "in_reply_to":1}}` + "\n")); err != nil {
+			t.Fatal(err)
+		}
+
+		// Ensure the response was received.
+		select {
+		case msg := <-respCh:
+			if got, want := msg.Src, "n2"; got != want {
+				t.Fatalf("Src=%s, want %s", got, want)
+			}
+			if got, want := msg.Dest, "n1"; got != want {
+				t.Fatalf("Dest=%s, want %s", got, want)
+			}
+			if got, want := string(msg.Body), `{"type":"foo_ok", "msg_id":2, "in_reply_to":1}`; got != want {
+				t.Fatalf("Body=%s, want %s", got, want)
+			}
+		case err := <-errorCh:
+			t.Fatal(err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for RPC response")
+		}
+	})
+
+	t.Run("ErrContextTimeout", func(t *testing.T) {
+		n, stdin, stdout := newNode(t)
+		initNode(t, n, "n1", []string{"n1", "n2"}, stdin, stdout)
+
+		// Send RPC call.
+		errorCh := make(chan error)
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			_, err := n.SyncRPC(ctx, "n2", map[string]any{"type": "foo", "bar": "baz"})
+			errorCh <- err
+		}()
+
+		// Ensure RPC request is received by the network. Do not write a response.
+		if line, err := stdout.ReadString('\n'); err != nil {
+			t.Fatal(err)
+		} else if got, want := line, `{"src":"n1","dest":"n2","body":{"bar":"baz","msg_id":1,"type":"foo"}}`+"\n"; got != want {
+			t.Fatalf("response=%s, want %s", got, want)
+		}
+
+		// Ensure the response was received.
+		select {
+		case err := <-errorCh:
+			if err == nil || err.Error() != `context deadline exceeded` {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for RPC response")
+		}
+	})
+
+	t.Run("RPCError", func(t *testing.T) {
+		n, stdin, stdout := newNode(t)
+		initNode(t, n, "n1", []string{"n1", "n2"}, stdin, stdout)
+
+		// Send RPC call.
+		errorCh := make(chan error)
+		go func() {
+			_, err := n.SyncRPC(context.Background(), "n2", map[string]any{"type": "foo", "bar": "baz"})
+			errorCh <- err
+		}()
+
+		// Ensure RPC request is received by the network.
+		if line, err := stdout.ReadString('\n'); err != nil {
+			t.Fatal(err)
+		} else if got, want := line, `{"src":"n1","dest":"n2","body":{"bar":"baz","msg_id":1,"type":"foo"}}`+"\n"; got != want {
+			t.Fatalf("response=%s, want %s", got, want)
+		}
+
+		// Write error response back to node.
+		if _, err := stdin.Write([]byte(`{"src":"n2", "dest":"n1", "body":{"type":"foo_ok", "msg_id":2, "in_reply_to":1, "code":20, "text":"key does not exist"}}` + "\n")); err != nil {
+			t.Fatal(err)
+		}
+
+		// Ensure the response was received.
+		select {
+		case err := <-errorCh:
+			var rpcError *maelstrom.RPCError
+			if !errors.As(err, &rpcError) {
+				t.Fatalf("unexpected error type: %#v", err)
+			} else if got, want := rpcError.Code, 20; got != want {
+				t.Fatalf("code=%v, want %v", got, want)
+			} else if got, want := rpcError.Text, "key does not exist"; got != want {
+				t.Fatalf("text=%v, want %v", got, want)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for RPC response")
+		}
+	})
 }
 
 // newNode initializes a test node and returns streams to read/write messages.
@@ -306,8 +344,13 @@ func newNode(tb testing.TB) (node *maelstrom.Node, stdin io.Writer, stdout *bufi
 	n.Stdout = outw
 
 	// Start the message loop.
-	errorCh := make(chan error)
-	go func() { errorCh <- n.Run() }()
+	done := make(chan error)
+	go func() {
+		if err := n.Run(); err != nil {
+			tb.Errorf("run error: %s", err)
+		}
+		close(done)
+	}()
 
 	// Ensure node stops by the end of the test.
 	tb.Cleanup(func() {
@@ -316,12 +359,9 @@ func newNode(tb testing.TB) (node *maelstrom.Node, stdin io.Writer, stdout *bufi
 		}
 
 		select {
-		case err := <-errorCh:
-			if err != nil {
-				tb.Fatalf("maelstrom.Node.Run(): %s", err)
-			}
 		case <-time.After(5 * time.Second):
 			tb.Fatalf("timeout waiting for node to stop")
+		case <-done:
 		}
 	})
 
@@ -342,5 +382,4 @@ func initNode(tb testing.TB, n *maelstrom.Node, id string, nodeIDs []string, std
 	} else if got, want := line, fmt.Sprintf(`{"src":"%s","body":{"in_reply_to":1,"type":"init_ok"}}`+"\n", id); got != want {
 		tb.Fatalf("init_ok=%s, want %s", got, want)
 	}
-
 }

--- a/demo/go/rpc_error.go
+++ b/demo/go/rpc_error.go
@@ -1,0 +1,93 @@
+package maelstrom
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// RPC error code constants.
+const (
+	Timeout                = 0
+	NotSupported           = 10
+	TemporarilyUnavailable = 11
+	MalformedRequest       = 12
+	Crash                  = 13
+	Abort                  = 14
+	KeyDoesNotExist        = 20
+	KeyAlreadyExists       = 21
+	PreconditionFailed     = 22
+	TxnConflict            = 30
+)
+
+// ErrorCodeText returns the text representation of an error code.
+func ErrorCodeText(code int) string {
+	switch code {
+	case Timeout:
+		return "Timeout"
+	case NotSupported:
+		return "NotSupported"
+	case TemporarilyUnavailable:
+		return "TemporarilyUnavailable"
+	case MalformedRequest:
+		return "MalformedRequest"
+	case Crash:
+		return "Crash"
+	case Abort:
+		return "Abort"
+	case KeyDoesNotExist:
+		return "KeyDoesNotExist"
+	case KeyAlreadyExists:
+		return "KeyAlreadyExists"
+	case PreconditionFailed:
+		return "PreconditionFailed"
+	case TxnConflict:
+		return "TxnConflict"
+	default:
+		return fmt.Sprintf("ErrorCode<%d>", code)
+	}
+}
+
+// ErrorCode returns the error code from err. Returns -1 if err is not an *RPCError.
+func ErrorCode(err error) int {
+	switch err := err.(type) {
+	case *RPCError:
+		return err.Code
+	default:
+		return -1
+	}
+}
+
+// RPCError represents a Maelstrom RPC error.
+type RPCError struct {
+	Code int
+	Text string
+}
+
+// NewRPCError returns a new instance of RPCError.
+func NewRPCError(code int, text string) *RPCError {
+	return &RPCError{
+		Code: code,
+		Text: text,
+	}
+}
+
+// Error returns a string-formatted error message.
+func (e *RPCError) Error() string {
+	return fmt.Sprintf("RPCError(%s, %q)", ErrorCodeText(e.Code), e.Text)
+}
+
+// MarshalJSON marshals the error into JSON format.
+func (e *RPCError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(rpcErrorJSON{
+		Type: "error",
+		Code: e.Code,
+		Text: e.Text,
+	})
+}
+
+// rpcErrorJSON is a struct for marshaling an RPCError to JSON.
+type rpcErrorJSON struct {
+	Type string `json:"type,omitempty"`
+	Code int    `json:"code,omitempty"`
+	Text string `json:"text,omitempty"`
+}

--- a/demo/go/rpc_error_test.go
+++ b/demo/go/rpc_error_test.go
@@ -1,0 +1,36 @@
+package maelstrom_test
+
+import (
+	"testing"
+
+	maelstrom "github.com/jepsen-io/maelstrom/demo/go"
+)
+
+func TestErrorCodeText(t *testing.T) {
+	for _, tt := range []struct {
+		code int
+		text string
+	}{
+		{maelstrom.Timeout, "Timeout"},
+		{maelstrom.NotSupported, "NotSupported"},
+		{maelstrom.TemporarilyUnavailable, "TemporarilyUnavailable"},
+		{maelstrom.MalformedRequest, "MalformedRequest"},
+		{maelstrom.Crash, "Crash"},
+		{maelstrom.Abort, "Abort"},
+		{maelstrom.KeyDoesNotExist, "KeyDoesNotExist"},
+		{maelstrom.KeyAlreadyExists, "KeyAlreadyExists"},
+		{maelstrom.PreconditionFailed, "PreconditionFailed"},
+		{maelstrom.TxnConflict, "TxnConflict"},
+		{1000, "ErrorCode<1000>"},
+	} {
+		if got, want := maelstrom.ErrorCodeText(tt.code), tt.text; got != want {
+			t.Errorf("code %d=%s, want %s", tt.code, got, want)
+		}
+	}
+}
+
+func TestRPCError_Error(t *testing.T) {
+	if got, want := maelstrom.NewRPCError(maelstrom.Crash, "foo").Error(), `RPCError(Crash, "foo")`; got != want {
+		t.Fatalf("error=%s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
This pull request refactors the Go `maelstrom.Node` implementation a bit to make it more ergonomic.

- Adds a `Node.SyncRPC()` method that accepts a `context.Context` which feels more natural for Go development instead of relying on callbacks.
- Adds a `KV` client so users don't need to manually implement `read`, `write`, and `cas`.
- Adds a convenience function called `malestrom.ErrorCode()` for obtaining an RPC error code from a regular `error` type.

This also fixes some bugs like `"init"` message handling blocking which prevented KV initiation calls.