### PR TITLE
Update wrapper script to work from anywhere

### DIFF
--- a/pkg/maelstrom
+++ b/pkg/maelstrom
@@ -2,4 +2,4 @@
 
 # A small wrapper script for invoking the Maelstrom jar, with arguments.
 
-exec java -Djava.awt.headless=true -jar $(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/lib/maelstrom.jar "$@"
+exec java -Djava.awt.headless=true -jar "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/lib/maelstrom.jar" "$@"

--- a/pkg/maelstrom
+++ b/pkg/maelstrom
@@ -2,4 +2,4 @@
 
 # A small wrapper script for invoking the Maelstrom jar, with arguments.
 
-exec java -Djava.awt.headless=true -jar lib/maelstrom.jar "$@"
+exec java -Djava.awt.headless=true -jar $(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/lib/maelstrom.jar "$@"


### PR DESCRIPTION
Prefix the directory of the maelstrom script to lib so you can call it from outside the maelstrom dir.