### PR TITLE
distributed lock workload with some demos in python

### DIFF
--- a/demo/python/echo-with-handlers.py
+++ b/demo/python/echo-with-handlers.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+"""A basic echo server"""
+
+from node import *
+
+@handler
+def echo(req):
+    reply(req, {'type': 'echo_ok', 'echo': req.body.echo})
+
+    # alternative using keyword arguments
+    # reply(req, type='echo_ok', echo=req.body.echo)
+
+# alternatives using on
+
+# on('echo', lambda req: reply(req, {'type': 'echo_ok', 'echo': req.body.echo}))
+# on('echo', lambda req: reply(req, type='echo_ok', echo=req.body.echo))
+
+receive()
+

--- a/demo/python/echo-with-receive.py
+++ b/demo/python/echo-with-receive.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+"""A basic echo server"""
+
+from node import *
+
+while req := receive():
+    reply(req, {'type': 'echo_ok', 'echo': req.body.echo})
+
+    # alternative using keyword arguments
+    # reply(req, type='echo_ok', echo=req.body.echo)
+
+

--- a/demo/python/lock-single-server.py
+++ b/demo/python/lock-single-server.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+"""Single server (centralized) lock for Maelstrom
+
+For 'lock' workload.  Will pass the test using, e.g.,
+"--node-count 1 --concurrency 3n", but will fail using, .e.g.,
+"--node-count 3".
+"""
+
+from node import *
+
+acquired = None
+requests = []
+
+while msg := receive():
+    match msg.body.type:
+        case 'lock':
+            if not acquired:
+                reply(msg, type='lock_ok')
+                acquired = msg
+            else:
+                requests.append(msg)
+        case 'unlock':
+            if acquired and acquired.src == msg.src:
+                reply(msg, type='unlock_ok')
+                if requests:
+                    acquired = requests.pop(0)
+                    reply(acquired, type='lock_ok')
+                else:
+                    acquired = None
+            else:
+                reply(msg, type='error', code=22,
+                      text='lock not owned by ' + msg.src)
+
+

--- a/demo/python/lock-wrong-impl.py
+++ b/demo/python/lock-wrong-impl.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+"""Obviously wrong implementation for 'lock' workload for Maelstrom"""
+
+from node import *
+
+on('lock', lambda req: reply(req, type='lock_ok'))
+on('unlock', lambda req: reply(req, type='unlock_ok'))
+
+receive()

--- a/demo/python/node.py
+++ b/demo/python/node.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+"""Basic support to implement a Maelstrom node.
+
+Allows initializing node (providing a default init handler), storing node_id
+and node_ids, sending or replying to messages, writing message handlers or
+using explicit receive (or some combination).
+
+Messages can be provided as a dictionary or SimpleNamespace and are returned
+as SimpleNamespace to allow dot notation. The message body in send and reply
+functions can be defined by a dict/SimpleNamespace or/and keyword arguments.
+"""
+
+import json
+import sys
+from types import SimpleNamespace as sn
+
+_node_id = None
+_node_ids = None
+_msg_id = 0
+_handlers = {}
+
+def node_id():
+    """Returns node id"""
+    return _node_id
+
+def node_ids():
+    """Returns list of ids of nodes in the cluster"""
+    return _node_ids
+
+def log(data, end='\n'):
+    """Writes to stderr."""
+    print(data, file=sys.stderr, flush=True, end=end)
+
+def send(dest, body={}, /, **kwds):
+    """Sends message to dest."""
+    global _msg_id
+    _msg_id += 1
+    if isinstance(body, dict):
+        body = body.copy()
+    else:
+        body = dict(vars(body))
+    body.update(kwds, msg_id=_msg_id)
+    msg = dict(src=_node_id, dest=dest, body=body)
+    data = json.dumps(msg, default=vars)
+    log("Sent " + data)
+    print(data, flush=True)
+
+def reply(req, body={}, /, **kwds):
+    """Sends reply message to given request."""
+    send(req.src, body, in_reply_to=req.body.msg_id, **kwds)
+
+def on(type, handler):
+    """Register handler for message type."""
+    _handlers[type] = handler
+
+def handler(func):
+    """Decorator: makes function as handler for namesake message type."""
+    _handlers[func.__name__] = func
+    return func
+
+@handler
+def init(msg):
+    """Default handler for init message."""
+    global _node_id, _node_ids
+    _node_id = msg.body.node_id
+    _node_ids = msg.body.node_ids
+    reply(msg, type='init_ok')
+
+def _receive():
+    data = sys.stdin.readline()
+    if data:
+        log("Received " + data, end='')
+        return json.loads(data, object_hook=lambda x: sn(**x))
+    else:
+        return None
+
+def receive():
+    """Returns next message received with no handler defined.
+
+    Messages with handlers defined are handled and not returned.
+    Returns None on EOF.
+    """
+    while True:
+        msg = _receive()
+        if msg is None:
+            return None
+        elif (t := msg.body.type) in _handlers:
+            _handlers[t](msg)
+        else:
+            return msg
+

--- a/src/maelstrom/core.clj
+++ b/src/maelstrom/core.clj
@@ -16,6 +16,7 @@
             [maelstrom.workload [broadcast :as broadcast]
                                 [echo :as echo]
                                 [kafka :as kafka]
+                                [lock :as lock]
                                 [g-set :as g-set]
                                 [g-counter :as g-counter]
                                 [pn-counter :as pn-counter]
@@ -38,6 +39,7 @@
   {:broadcast       broadcast/workload
    :echo            echo/workload
    :kafka           kafka/workload
+   :lock            lock/workload
    :g-set           g-set/workload
    :g-counter       g-counter/workload
    :pn-counter      pn-counter/workload

--- a/src/maelstrom/workload/lock.clj
+++ b/src/maelstrom/workload/lock.clj
@@ -1,0 +1,79 @@
+(ns maelstrom.workload.lock
+  "A distributed lock workload: sends lock and unlock messages."
+  (:require [maelstrom [client :as c]]
+            [jepsen [checker :as checker]
+                    [client :as client]
+                    [generator :as gen]]
+            [schema.core :as s]))
+
+(c/defrpc lock!
+  "Clients send `lock` messages to servers. Servers should respond with
+  `lock_ok` messages when the lock is granted."
+  {:type (s/eq "lock")}
+  {:type (s/eq "lock_ok")})
+
+(c/defrpc unlock!
+  "Clients send `unlock` messages to servers. Servers should respond with
+  `unlock_ok` messages acking that the lock is released"
+  {:type (s/eq "unlock")}
+  {:type (s/eq "unlock_ok")})
+
+(defn client
+  ([net]
+   (client net nil nil))
+  ([net conn node]
+   (reify client/Client
+     (open! [this test node]
+       (client net (c/open! net) node))
+
+     (setup! [this test])
+
+     (invoke! [_ test op]
+       (c/with-errors op #{}
+         (let [rpc (case (:f op) :lock lock! :unlock unlock!)
+               timeout (* 1000 (:time-limit test))] ; timeout at most last op from each client
+           (rpc conn node {} timeout)
+           (assoc op :type :ok))))
+
+     (teardown! [_ test])
+
+     (close! [_ test]
+       (c/close! conn)))))
+
+(defn checker
+  "Expects that a lock is only given when released by previous owner."
+  []
+  (reify checker/Checker
+    (check [this test history opts]
+      (let [[_ errs]
+            (reduce
+              (fn [[acquired errors] op]
+                (case [(:type op) (:f op)]
+                  [:ok :lock]
+                  (if acquired
+                    [acquired (conj errors
+                                   (str "already acquired by process " acquired
+                                        " when lock completed at " op))]
+                    [(:process op) errors])
+                  [:invoke :unlock] ; lock can complete before unlock completes
+                  (if (= acquired (:process op))
+                    [nil errors]
+                    [acquired (conj errors
+                                   (str "lock not owned when unlock invoked at "
+                                        op))])
+                  [acquired errors]))
+              [nil []]
+              history)]
+        {:valid? (empty? errs)
+         :errors errs}))))
+
+(defn workload
+  "Constructs a workload for a distributed lock, given option from the CLI
+  test constructor:
+
+      {:net     A Maelstrom network}"
+  [opts]
+  {:client          (client (:net opts))
+   :generator       (gen/each-thread (cycle [{:f :lock} {:f :unlock}]))
+   :checker   (checker)})
+


### PR DESCRIPTION
A distributed lock workload. Clients send `lock` messages to servers. Servers should respond with `lock_ok` messages when the lock is granted. Clients send `unlock` messages to servers. Servers should respond with `unlock_ok` messages acking that the lock is released. A checker is included.

Includes some demos in python: an obviously wrong lock implementation and a centralized (single-server) lock, written using a basic node.py, also provided. It is being used in a distributed systems course, where students are asked to write a distributed lock.