### PR TITLE
Fix typo in error code range.

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -120,7 +120,7 @@ the request which caused this error.
 
 The `code` is an integer which indicates the type of error which occurred.
 Maelstrom defines several error types, and you can also invent your own.
-Codes 0-9999 are reserved for Maelstrom's use; codes 1000 and above are free
+Codes 0-999 are reserved for Maelstrom's use; codes 1000 and above are free
 for your own purposes.
 
 The `text` field is a free-form string. It is optional, and may contain any

--- a/resources/protocol-intro.md
+++ b/resources/protocol-intro.md
@@ -120,7 +120,7 @@ the request which caused this error.
 
 The `code` is an integer which indicates the type of error which occurred.
 Maelstrom defines several error types, and you can also invent your own.
-Codes 0-9999 are reserved for Maelstrom's use; codes 1000 and above are free
+Codes 0-999 are reserved for Maelstrom's use; codes 1000 and above are free
 for your own purposes.
 
 The `text` field is a free-form string. It is optional, and may contain any


### PR DESCRIPTION
I'm guessing this was the typo, rather than the 1000