### PR TITLE
Fix documentation describing reserved error codes.

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -120,7 +120,7 @@ the request which caused this error.
 
 The `code` is an integer which indicates the type of error which occurred.
 Maelstrom defines several error types, and you can also invent your own.
-Codes 0-9999 are reserved for Maelstrom's use; codes 1000 and above are free
+Codes 0-999 are reserved for Maelstrom's use; codes 1000 and above are free
 for your own purposes.
 
 The `text` field is a free-form string. It is optional, and may contain any

--- a/resources/protocol-intro.md
+++ b/resources/protocol-intro.md
@@ -120,7 +120,7 @@ the request which caused this error.
 
 The `code` is an integer which indicates the type of error which occurred.
 Maelstrom defines several error types, and you can also invent your own.
-Codes 0-9999 are reserved for Maelstrom's use; codes 1000 and above are free
+Codes 0-999 are reserved for Maelstrom's use; codes 1000 and above are free
 for your own purposes.
 
 The `text` field is a free-form string. It is optional, and may contain any


### PR DESCRIPTION
Prior to this commit, the documentation gave conflicting information about which codes are reserved for Maelstrom's use and which are available for application-specific purposes. Due to a typo, the two categories had overlapping ranges.

This commit consistently specifies that codes 999 and below are reserved, while codes 1000 and above are free for application use.