### PR TITLE
Fix a typo

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -94,7 +94,7 @@ like so:
 ```
 
 The `node_id` field indicates the ID of the node which is receiving this
-message: here, the node ID is "n1". Your node should remember this ID and
+message: here, the node ID is "n3". Your node should remember this ID and
 include it as the `src` of any message it sends.
 
 The `node_ids` field lists all nodes in the cluster, including the recipient.


### PR DESCRIPTION
I believe there is a typo in the init message:

```json
{
  "type":     "init",
  "msg_id":   1,
  "node_id":  "n3",
  "node_ids": ["n1", "n2", "n3"]
}
```
The `node_id` field indicates the ID of the node which is receiving this 
message: here, the node ID is "n1"

updated it to `n3`

