### PR TITLE
Mention the fact that the node must respond to the init message

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -100,6 +100,16 @@ include it as the `src` of any message it sends.
 The `node_ids` field lists all nodes in the cluster, including the recipient.
 All nodes receive an identical list; you may use its order if you like.
 
+In response to the `init` message, each node must respond with a message of 
+type `init_ok`. 
+
+```json
+{
+  "type":        "init_ok",
+  "in_reply_to": 1
+}
+```
+
 ## Errors
 
 In response to a Maelstrom RPC request, a node may respond with an *error*


### PR DESCRIPTION
Hi, I'm trying to implement my own library to interoperate with maelstrom, and found out that each node has to send a response to the `init` message. This is currently not documented. I had to take a look inside the go library source code to find the expected behavior. https://github.com/jepsen-io/maelstrom/blob/main/demo/go/node.go#L182