### PR TITLE
Improve wrapper script

### DIFF
--- a/pkg/maelstrom
+++ b/pkg/maelstrom
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # A small wrapper script for invoking the Maelstrom jar, with arguments.
 


### PR DESCRIPTION
On some systems like macOS, `/bin/bash` is not the desired Bash version. `/usr/bin/env bash` searches $PATH for Bash and can find a more recent version, like one installed via Homebrew.

Tested on Fedora Linux. (But I use `#!/usr/bin/env bash` in my Bash scripts on Macs as well)