### PR TITLE
Allow maelstrom to be executed from anywhere

### DIFF
--- a/pkg/maelstrom
+++ b/pkg/maelstrom
@@ -2,4 +2,6 @@
 
 # A small wrapper script for invoking the Maelstrom jar, with arguments.
 
-exec java -Djava.awt.headless=true -jar lib/maelstrom.jar "$@"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+exec java -Djava.awt.headless=true -jar "${SCRIPT_DIR}/lib/maelstrom.jar" "$@"


### PR DESCRIPTION
When working on code for one of the scenarios, for example in `~/challenge/echo`, you first have to switch to `/path/to/maelstrom` to then execute `./maelstrom ... --bin ~/challenge/echo/echo ...`.

This is a bit cumbersome, and can also lead to mixing up the proper binary path (as I did myself [here](https://github.com/jepsen-io/maelstrom/issues/42)).

With the proposed change, you can stay in `~/challenge/echo` and execute `/path/to/maelstrom/maelstrom ... --bin ./echo ...`.