### PR TITLE
properly handle symlinks

### DIFF
--- a/pkg/maelstrom
+++ b/pkg/maelstrom
@@ -2,6 +2,6 @@
 
 # A small wrapper script for invoking the Maelstrom jar, with arguments.
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$( cd -- "$( dirname "$(readlink -f "${BASH_SOURCE[0]}")" )" &> /dev/null && pwd )
 
 exec java -Djava.awt.headless=true -jar "${SCRIPT_DIR}/lib/maelstrom.jar" "$@"


### PR DESCRIPTION
if `maelstrom` is a symlink then the wrapper script doesn't work properly.

For example, I install `maelstrom` to `~/.local/share/maelstrom` and symlink the script to `~/.local/bin`; the script as currently composed gives:

```
$ maelstrom help
Error: Unable to access jarfile ~/.local/bin/lib/maelstrom.jar
```

because it's searching in `bin` instead of `share`.

To fix it, I took the `readlink` solution from #34 and added it to the script from #46.

After applying the patch, the symlink works as expected:

```
$ maelstrom help
WARNING: abs already refers to: #'clojure.core/abs in namespace: clojure.core.matrix.impl.mathsops, being replaced by: #'clojure.core.matrix.impl.mathsops/abs
Warning: protocol #'clojure.core.matrix.protocols/PMathsFunctions is overwriting function abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: clojure.core.matrix.protocols, being replaced by: #'clojure.core.matrix.protocols/abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: clojure.core.matrix, being replaced by: #'clojure.core.matrix/abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: clojure.core.matrix.dataset, being replaced by: #'clojure.core.matrix/abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: incanter.core, being replaced by: #'incanter.core/abs
Usage: lein run -- COMMAND [OPTIONS ...]
Commands: analyze, demo, doc, serve, test
```