### PR TITLE
maelstrom.ErrorCode: support errors nesting

### DIFF
--- a/demo/go/rpc_error.go
+++ b/demo/go/rpc_error.go
@@ -2,6 +2,7 @@ package maelstrom
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -47,14 +48,13 @@ func ErrorCodeText(code int) string {
 	}
 }
 
-// ErrorCode returns the error code from err. Returns -1 if err is not an *RPCError.
+// ErrorCode returns the error code from err. Returns -1 if err does not have an *RPCError.
 func ErrorCode(err error) int {
-	switch err := err.(type) {
-	case *RPCError:
-		return err.Code
-	default:
-		return -1
+	var rpc *RPCError
+	if errors.As(err, &rpc) {
+		return rpc.Code
 	}
+	return -1
 }
 
 // RPCError represents a Maelstrom RPC error.

--- a/demo/go/rpc_error_test.go
+++ b/demo/go/rpc_error_test.go
@@ -1,6 +1,7 @@
 package maelstrom_test
 
 import (
+	"fmt"
 	"testing"
 
 	maelstrom "github.com/jepsen-io/maelstrom/demo/go"
@@ -32,5 +33,17 @@ func TestErrorCodeText(t *testing.T) {
 func TestRPCError_Error(t *testing.T) {
 	if got, want := maelstrom.NewRPCError(maelstrom.Crash, "foo").Error(), `RPCError(Crash, "foo")`; got != want {
 		t.Fatalf("error=%s, want %s", got, want)
+	}
+}
+
+func TestRPCError_ErrorCode(t *testing.T) {
+	var err error = maelstrom.NewRPCError(maelstrom.Crash, "foo")
+	if maelstrom.ErrorCode(err) != maelstrom.Crash {
+		t.Fatalf("error=%d, want %d", maelstrom.ErrorCode(err), maelstrom.Crash)
+	}
+
+	err = fmt.Errorf("foo: %w", err)
+	if maelstrom.ErrorCode(err) != maelstrom.Crash {
+		t.Fatalf("error=%d, want %d", maelstrom.ErrorCode(err), maelstrom.Crash)
 	}
 }


### PR DESCRIPTION
Go framework needs to support errors nesting via "errors" package:

	err = fmt.Errorf("foo: %w", error(maelstrom.NewRPCError(maelstrom.Crash, "foo")))
	if maelstrom.ErrorCode(err) == maelstrom.Crash {
		// do something useful
	}

For checking wrapped errors returned from KV and another API that can fail due to whatever reason including context timeouts