### PR TITLE
Fix quotes for a snippet to render md properly.

### DIFF
--- a/doc/06-raft/02-leader-election.md
+++ b/doc/06-raft/02-leader-election.md
@@ -498,7 +498,7 @@ Sent {:dest=>"n1", :src=>"n2", :body=>{:type=>"request_vote", :term=>1, :candida
 Became candidate for term 1
 Received {:dest=>"n2", :src=>"n1", :body=>{:type=>"request_vote", :term=>1, :candidate_id=>"n1", :last_log_index=>1, :last_log_term=>0, :msg_id=>2}, :id=>9}
 Already voted for n2; not granting vote.
-``
+```
 
 Ah, so this is a bit of a problem. Every node wakes up exactly every 1 seconds
 to run their election process, which means they all tend to run elections


### PR DESCRIPTION
Hi there, thank you for this amazing project! 

As I was following along this guide, I came across a tiny markdown typo where a code snippet was (likely accidentally) double quoted instead of triple.

This PR fixes it.