### PR TITLE
Fix small typo in lin-kv workload docs

### DIFF
--- a/doc/workloads.md
+++ b/doc/workloads.md
@@ -466,7 +466,7 @@ Response:
 ### RPC: Write! 
 
 Blindly overwrites the value of a key. Creates keys if they do not presently
-exist. Servers should respond with a `read_ok` response once the write is
+exist. Servers should respond with a `write_ok` response once the write is
 complete. 
 
 Request:


### PR DESCRIPTION
For the `write` RPC, the response should be `write_ok` and not `read_ok`.