### PR TITLE
Fix default argument for Workload

### DIFF
--- a/src/maelstrom/core.clj
+++ b/src/maelstrom/core.clj
@@ -139,7 +139,7 @@
     :missing "Expected a --bin PATH_TO_BINARY to test"]
 
    ["-w" "--workload NAME" "What workload to run."
-    :default "lin-kv"
+    :default  :lin-kv
     :parse-fn keyword
     :validate [workloads (cli/one-of workloads)]]
    ])


### PR DESCRIPTION
It was supposed to be a keyword, not a string, and now it works!

Closes #78 