### PR TITLE
Add basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+ARG IMAGE_BASE=clojure
+ARG BUILD_IMAGE=${IMAGE_BASE}:temurin-17-lein-bookworm
+ARG RUN_IMAGE=${BUILD_IMAGE}-slim
+
+FROM ${BUILD_IMAGE} AS build
+WORKDIR /maelstrom
+
+# TODO: Figure out which files to ignore
+COPY . .
+
+RUN lein deps
+RUN lein uberjar
+RUN mv /maelstrom/target/maelstrom*standalone.jar /maelstrom/maelstrom.jar
+
+FROM ${RUN_IMAGE} AS run
+WORKDIR /maelstrom
+
+COPY --from=build /maelstrom/maelstrom.jar /maelstrom/maelstrom.jar
+
+# maelstrom requires explicit root user within Docker
+USER root
+ENTRYPOINT ["java", "-Djava.awt.headless=true", "-jar", "/maelstrom/maelstrom.jar"]

--- a/README.md
+++ b/README.md
@@ -155,6 +155,25 @@ For transactional tests, you can control transaction generation using
 
 SSH options are unused; Maelstrom runs entirely on the local node.
 
+<!--
+
+TODO: Once there's an "official" Docker image, add official image link here and uncomment these docs:
+
+### Docker Container Setup
+
+If you want to build the Docker container, you can run:
+```sh
+docker build -t maelstrom:latest .
+```
+
+And then you can run the CLI with:
+
+```sh
+docker run maelstrom:latest
+```
+
+-->
+
 ## Troubleshooting
 
 ### Running ./maelstrom complains it's missing maelstrom.jar


### PR DESCRIPTION
I want to be able to run `maelstrom` without installing a JVM/Clojure/Leiningen, so I figured I'd create a simple `Dockerfile` for it. 😄

@aphyr I added some commented-out documentation in the README. I figured it can stay commented out until the Jepsen/maelstrom team decides on how to publish [an official image on Docker Hub](https://hub.docker.com/)? 😅 