### PR TITLE
Separate Request and Response enums in Rust demo

### DIFF
--- a/demo/rust/src/bin/broadcast.rs
+++ b/demo/rust/src/bin/broadcast.rs
@@ -37,7 +37,7 @@ impl Node for Handler {
         match msg {
             Ok(Request::Read {}) => {
                 let data = self.snapshot();
-                let msg = Request::ReadOk { messages: data };
+                let msg = Response::ReadOk { messages: data };
                 return runtime.reply(req, msg).await;
             }
             Ok(Request::Broadcast { message: element }) => {
@@ -81,13 +81,18 @@ impl Handler {
 enum Request {
     Init {},
     Read {},
-    ReadOk {
-        messages: Vec<u64>,
-    },
     Broadcast {
         message: u64,
     },
     Topology {
         topology: HashMap<String, Vec<String>>,
+    },
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+enum Response {
+    ReadOk {
+        messages: Vec<u64>,
     },
 }

--- a/demo/rust/src/bin/lin_kv.rs
+++ b/demo/rust/src/bin/lin_kv.rs
@@ -33,15 +33,15 @@ impl Node for Handler {
         match msg {
             Ok(Request::Read { key }) => {
                 let value = self.s.get(ctx, key.to_string()).await?;
-                return runtime.reply(req, Request::ReadOk { value }).await;
+                return runtime.reply(req, Response::ReadOk { value }).await;
             }
             Ok(Request::Write { key, value }) => {
                 self.s.put(ctx, key.to_string(), value).await?;
-                return runtime.reply(req, Request::WriteOk {}).await;
+                return runtime.reply(req, Response::WriteOk {}).await;
             }
             Ok(Request::Cas { key, from, to, put }) => {
                 self.s.cas(ctx, key.to_string(), from, to, put).await?;
-                return runtime.reply(req, Request::CasOk {}).await;
+                return runtime.reply(req, Response::CasOk {}).await;
             }
             _ => done(runtime, req),
         }
@@ -58,14 +58,10 @@ enum Request {
     Read {
         key: u64,
     },
-    ReadOk {
-        value: i64,
-    },
     Write {
         key: u64,
         value: i64,
     },
-    WriteOk {},
     Cas {
         key: u64,
         from: i64,
@@ -73,5 +69,14 @@ enum Request {
         #[serde(default, rename = "create_if_not_exists")]
         put: bool,
     },
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+enum Response {
+    ReadOk {
+        value: i64,
+    },
+    WriteOk {},
     CasOk {},
 }


### PR DESCRIPTION
Hi, in the Rust demo, I feel like the variants representing responses from the server, such as ReadOk or AddOk, would be better suited in a separate Response enum, as they are not expected from a client's request. 