### PR TITLE
Add Raft demo in Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,7 @@ store/
 .DS_Store
 .idea
 /demo/rust/target
+/demo/go/cmd/maelstrom-raft/maelstrom-raft
+/demo/go/cmd/maelstrom-raft/vendor
+maelstrom
 __pycache__/

--- a/demo/go/cmd/maelstrom-raft/README.md
+++ b/demo/go/cmd/maelstrom-raft/README.md
@@ -1,0 +1,51 @@
+# Raft Demo in Go with Maelstrom
+
+This repository contains a demo of the Raft consensus algorithm implemented in Go, designed to run within the Maelstrom framework.
+
+## Prerequisites
+
+To run this demo, you will need the following installed on your system:
+
+- Go (version 1.21.0 or later)
+- Maelstrom (latest version)
+
+## Getting Started
+
+Follow these steps to build and run the Raft demo:
+
+### 1. Clone the Repository
+
+Clone the Maelstrom repository if you haven't already:
+
+```shell
+git clone https://github.com/jepsen-io/maelstrom.git
+cd maelstrom
+```
+
+### 2. Build the Raft Demo
+
+Navigate to the Raft demo directory and build the Go application:
+```shell
+(cd demo/go/cmd/maelstrom-raft/ && go build)
+```
+
+### 3. Run the Demo
+
+Execute the following command to run the Raft demo using Maelstrom with the specified parameters:
+
+```shell
+./maelstrom test -w lin-kv --bin demo/go/cmd/maelstrom-raft/maelstrom-raft --node-count 3 --concurrency 4n --rate 40 --time-limit 60 --nemesis partition --nemesis-interval 10 --test-count 1
+```
+
+### Explanation of the Command
+
+- `./maelstrom test` : Invokes the Maelstrom test runner.
+- `-w lin-kv`: Specifies the workload to be linearizable key-value store.
+- `--bin demo/go/cmd/maelstrom-raft/maelstrom-raft`: Points to the built Raft demo binary.
+- `--node-count 3`: Sets the number of nodes in the Raft cluster to 3.
+- `--concurrency 4n`: Sets the concurrency level to 4 operations per node.
+- `--rate 30`: Sets the rate of operations per second.
+- `--time-limit 60`: Sets the time limit for the test to 60 seconds.
+- `--nemesis partition`: Introduces network partitions as the fault injection.
+- `--nemesis-interval 10`: time in seconds between nemesis operations, on average.
+` `--test-count 10`: Runs the test for 10 counts.

--- a/demo/go/cmd/maelstrom-raft/go.mod
+++ b/demo/go/cmd/maelstrom-raft/go.mod
@@ -1,0 +1,12 @@
+module github.com/jepsen-io/maelstrom/demo/go/cmd/maelstrom-raft
+
+go 1.21.0
+
+require (
+	github.com/jepsen-io/maelstrom/demo/go v0.0.0-20240408130303-0186f398f965
+	github.com/samber/lo v1.39.0
+	golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d
+)
+
+// Use local dependency
+replace github.com/jepsen-io/maelstrom/demo/go => ../../

--- a/demo/go/cmd/maelstrom-raft/go.sum
+++ b/demo/go/cmd/maelstrom-raft/go.sum
@@ -1,0 +1,4 @@
+github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
+github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
+golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d h1:N0hmiNbwsSNwHBAvR3QB5w25pUwH4tK0Y/RltD1j1h4=
+golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=

--- a/demo/go/cmd/maelstrom-raft/handlers.go
+++ b/demo/go/cmd/maelstrom-raft/handlers.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	maelstrom "github.com/jepsen-io/maelstrom/demo/go"
+	"log"
+)
+
+// When a node requests our vote...
+func (raft *RaftNode) requestVote(msg maelstrom.Message) error {
+	var requestVoteMsgBody RequestVoteMsgBody
+	if err := json.Unmarshal(msg.Body, &requestVoteMsgBody); err != nil {
+		return err
+	}
+
+	raft.maybeStepDown(requestVoteMsgBody.Term)
+	grant := false
+
+	if requestVoteMsgBody.Term < raft.currentTerm {
+		log.Printf("candidate Term %d lower than %d not granting vote \n", requestVoteMsgBody.Term, raft.currentTerm)
+	} else if raft.votedFor != "" {
+		log.Printf("already voted for %s not granting vote \n", raft.votedFor)
+	} else if requestVoteMsgBody.LastLogTerm < raft.log.lastTerm() {
+		log.Printf("have log Entries From Term %d which is newer than remote Term %d not granting vote\n", raft.log.lastTerm(), requestVoteMsgBody.LastLogTerm)
+	} else if requestVoteMsgBody.LastLogTerm == raft.log.lastTerm() && requestVoteMsgBody.LastLogIndex < raft.log.size() {
+		log.Printf("our logs are both at Term %d but our log is %d and theirs is only %d \n", raft.log.lastTerm(), raft.log.size(), requestVoteMsgBody.LastLogIndex)
+	} else {
+		log.Printf("before raft.votedFor %s\n", raft.votedFor)
+		log.Printf("CandidateId: %s\n", requestVoteMsgBody.CandidateId)
+		log.Printf("Granting vote To %s\n", msg.Src)
+		grant = true
+		raft.votedFor = requestVoteMsgBody.CandidateId
+		raft.resetElectionDeadline()
+		log.Printf("after raft.votedFor %s\n", raft.votedFor)
+	}
+
+	err := raft.node.Reply(msg, map[string]interface{}{
+		"type":         MsgTypeRequestVoteResult,
+		"term":         raft.currentTerm,
+		"vote_granted": grant,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (raft *RaftNode) appendEntries(msg maelstrom.Message) error {
+	var appendEntriesMsgBody AppendEntriesMsgBody
+	err := json.Unmarshal(msg.Body, &appendEntriesMsgBody)
+	if err != nil {
+		panic(err)
+	}
+
+	raft.maybeStepDown(appendEntriesMsgBody.Term)
+
+	result := map[string]interface{}{
+		"type":    MsgTypeAppendEntriesResult,
+		"term":    raft.currentTerm,
+		"success": false,
+	}
+
+	if appendEntriesMsgBody.Term < raft.currentTerm {
+		// leader is behind us
+		raft.node.Reply(msg, result)
+		return nil
+	}
+
+	// This leader is valid; remember them and don't try to run our own election for a bit
+	raft.leaderId = appendEntriesMsgBody.LeaderId
+	raft.resetElectionDeadline()
+
+	// Check previous entry To see if it matches
+	if appendEntriesMsgBody.PrevLogIndex <= 0 {
+		panic(fmt.Errorf("out of bounds previous log index %d \n", appendEntriesMsgBody.PrevLogIndex))
+	}
+
+	if appendEntriesMsgBody.PrevLogIndex > len(raft.log.Entries) || (appendEntriesMsgBody.PrevLogTerm != raft.log.get(appendEntriesMsgBody.PrevLogIndex).Term) {
+		// We disagree on the previous term
+		raft.node.Reply(msg, result)
+		return nil
+	}
+
+	// We agree on the previous log Term; truncate and append
+	raft.log.truncate(appendEntriesMsgBody.PrevLogIndex)
+	raft.log.append(appendEntriesMsgBody.Entries)
+
+	// Advance commit pointer
+	if raft.commitIndex < appendEntriesMsgBody.LeaderCommit {
+		raft.commitIndex = min(appendEntriesMsgBody.LeaderCommit, raft.log.size())
+		raft.advanceCommitIndex()
+	}
+
+	// Acknowledge
+	result["success"] = true
+	raft.node.Reply(msg, result)
+	return nil
+}
+
+func (raft *RaftNode) setupHandlers() error {
+	// Handle Client KV requests
+	kvRequests := func(msg maelstrom.Message, op Operation) error {
+		if raft.state == StateLeader {
+			raft.log.append([]Entry{{
+				Term: raft.currentTerm,
+				Op:   &op,
+				Msg:  msg,
+			}})
+		} else if raft.leaderId != "" {
+			// we're not the leader, but we can proxy to one
+			msg.Dest = raft.leaderId
+			raft.node.Send(raft.leaderId, msg.Body)
+		} else {
+			return raft.node.Reply(msg, &ErrorMsgBody{
+				Type: MsgTypeError,
+				Code: ErrCodeTemporarilyUnavailable,
+				Text: ErrNotLeader,
+			})
+		}
+
+		return nil
+	}
+
+	kvReadRequest := func(msg maelstrom.Message) error {
+		var readMsgBody ReadMsgBody
+		err := json.Unmarshal(msg.Body, &readMsgBody)
+		if err != nil {
+			panic(err)
+		}
+
+		return kvRequests(msg, Operation{
+			Type:   readMsgBody.Type,
+			MsgId:  readMsgBody.MsgId,
+			Key:    readMsgBody.Key,
+			Client: readMsgBody.Client,
+		})
+	}
+
+	kvWriteRequest := func(msg maelstrom.Message) error {
+		var writeMsgBody WriteMsgBody
+		err := json.Unmarshal(msg.Body, &writeMsgBody)
+		if err != nil {
+			panic(err)
+		}
+
+		return kvRequests(msg, Operation{
+			Type:   writeMsgBody.Type,
+			MsgId:  int(writeMsgBody.MsgId),
+			Key:    writeMsgBody.Key,
+			Client: writeMsgBody.Client,
+			Value:  writeMsgBody.Value,
+		})
+	}
+
+	kvCasRequest := func(msg maelstrom.Message) error {
+		var casMsgBody CasMsgBody
+		err := json.Unmarshal(msg.Body, &casMsgBody)
+		if err != nil {
+			panic(err)
+		}
+
+		return kvRequests(msg, Operation{
+			Type:   casMsgBody.Type,
+			MsgId:  casMsgBody.MsgId,
+			Key:    casMsgBody.Key,
+			Client: casMsgBody.Client,
+			From:   casMsgBody.From,
+			To:     casMsgBody.To,
+		})
+	}
+
+	raft.node.Handle(string(MsgTypeRead), kvReadRequest)
+	raft.node.Handle(string(MsgTypeWrite), kvWriteRequest)
+	raft.node.Handle(string(MsgTypeCas), kvCasRequest)
+	raft.node.Handle(string(MsgTypeRequestVote), raft.requestVote)
+	raft.node.Handle(string(MsgTypeAppendEntries), raft.appendEntries)
+	return nil
+}

--- a/demo/go/cmd/maelstrom-raft/kv_store.go
+++ b/demo/go/cmd/maelstrom-raft/kv_store.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"sync"
+)
+
+// KVStore A state machine providing a Key-Value store.
+type KVStore struct {
+	state map[int]int
+	wu    sync.Mutex
+}
+
+func (kvStore *KVStore) init() {
+	kvStore.state = map[int]int{}
+}
+
+func (kvStore *KVStore) apply(op Operation) any {
+	kvStore.wu.Lock()
+	defer kvStore.wu.Unlock()
+	// Applies an operation to the state machine, and returns a response message.
+	t := op.Type
+	k := op.Key
+
+	var body any
+	// Handle state transition
+	if t == MsgTypeRead {
+		if value, ok := kvStore.state[k]; ok {
+			body = &ReadOkMsgBody{
+				Type:  MsgTypeReadOk,
+				Value: value,
+			}
+		} else {
+			body = &ErrorMsgBody{
+				Type: MsgTypeError,
+				Code: ErrCodeKeyDoesNotExist,
+				Text: ErrTxtNotFound,
+			}
+		}
+	} else if t == MsgTypeWrite {
+		kvStore.state[k] = op.Value
+		body = &WriteOkMsgBody{
+			Type: MsgTypeWriteOk,
+		}
+	} else if t == MsgTypeCas {
+		if value, ok := kvStore.state[k]; !ok {
+			body = &ErrorMsgBody{
+				Type: MsgTypeError,
+				Code: ErrCodeKeyDoesNotExist,
+				Text: ErrTxtNotFound,
+			}
+		} else if value != op.From {
+			body = &ErrorMsgBody{
+				Type: MsgTypeError,
+				Code: ErrCodePreconditionFailed,
+				Text: fmt.Sprintf(ErrExpectedButHad, op.From, value),
+			}
+		} else {
+			kvStore.state[k] = op.To
+			body = &CasOkMsgBody{
+				Type: MsgTypeCasOk,
+			}
+		}
+	}
+
+	log.Printf("KV:\n %v \n", kvStore.state)
+	return body
+}
+
+func newKVStore() *KVStore {
+	kvStore := KVStore{}
+	kvStore.init()
+	return &kvStore
+}

--- a/demo/go/cmd/maelstrom-raft/log.go
+++ b/demo/go/cmd/maelstrom-raft/log.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"github.com/samber/lo"
+)
+
+type Log struct {
+	Entries []Entry
+}
+
+func (log *Log) init() {
+	// Note that we provide a default entry here, which simplifies
+	// some default cases involving empty logs.
+	log.Entries = []Entry{{
+		Term: 0,
+	}}
+}
+
+func (log *Log) get(index int) Entry {
+	// Return a log entry by index. Note that Raft's log is 1-indexed.
+	return log.Entries[index-1]
+}
+
+func (log *Log) append(entries []Entry) {
+	// Appends multiple entries to the log
+	log.Entries = append(log.Entries, entries...)
+}
+
+func (log *Log) last() Entry {
+	// Returns the most recent entry
+	return log.Entries[len(log.Entries)-1]
+}
+
+func (log *Log) lastTerm() int {
+	// What's the term of the last entry in the log?
+	return log.last().Term // TODO: if index exception return 0
+}
+
+func (log *Log) size() int {
+	return len(log.Entries)
+}
+
+func (log *Log) truncate(size int) {
+	// Truncate the log to this many entries
+	log.Entries = lo.Slice(log.Entries, 0, size)
+}
+
+func (log *Log) fromIndex(index int) []Entry {
+	if index <= 0 {
+		panic(fmt.Errorf("illegal index %d", index))
+	}
+
+	return lo.Slice(log.Entries, index-1, len(log.Entries))
+}
+
+func newLog() *Log {
+	log := Log{}
+	log.init()
+	return &log
+}

--- a/demo/go/cmd/maelstrom-raft/main.go
+++ b/demo/go/cmd/maelstrom-raft/main.go
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	raft, err := newRaftNode()
+	if err != nil {
+		panic(err)
+	}
+
+	if err := raft.node.Run(); err != nil {
+		panic(err)
+	}
+}

--- a/demo/go/cmd/maelstrom-raft/raft.go
+++ b/demo/go/cmd/maelstrom-raft/raft.go
@@ -1,0 +1,342 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	maelstrom "github.com/jepsen-io/maelstrom/demo/go"
+	"github.com/samber/lo"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/rand"
+	"log"
+	"sync"
+	"time"
+)
+
+const (
+	StateCandidate = "candidate"
+	StateFollower  = "follower"
+	StateLeader    = "leader"
+)
+
+type RaftNode struct {
+	electionTimeout        time.Duration
+	heartbeatInterval      time.Duration
+	minReplicationInterval time.Duration
+
+	electionDeadline int64
+	stepDownDeadline int64
+	lastReplication  int64
+
+	// Raft State
+	state       string
+	currentTerm int
+	votedFor    string
+
+	// Leader state
+	nextIndex   map[string]int
+	matchIndex  map[string]int
+	commitIndex int
+	lastApplied int
+	leaderId    string
+
+	// Components
+	log          *Log
+	node         *maelstrom.Node
+	stateMachine *KVStore
+
+	// Concurrency Locks
+	becomeCandidateMu       sync.Mutex
+	becomeFollowerMu        sync.Mutex
+	advanceTermMu           sync.Mutex
+	resetElectionDeadlineMu sync.Mutex
+	requestVotesMu          sync.Mutex
+	requestVoteResHandlerMu sync.Mutex
+	maybeStepDownMu         sync.Mutex
+	becomeLeaderMu          sync.Mutex
+	replicateLogMu          sync.Mutex
+	appendEntriesResMu      sync.Mutex
+	resetStepDownDeadlineMu sync.Mutex
+	advanceCommitIndexMu    sync.Mutex
+}
+
+func (raft *RaftNode) init() error {
+	// Heartbeats & timeouts
+	raft.electionTimeout = 2 * time.Second              // Time before election, in seconds
+	raft.heartbeatInterval = 1 * time.Second            // Time between heartbeats, in seconds
+	raft.minReplicationInterval = 50 * time.Millisecond // Don't replicate TOO frequently
+
+	raft.electionDeadline = time.Now().UnixNano() // Next election, in epoch seconds
+	raft.stepDownDeadline = time.Now().UnixNano() // When To step down automatically
+	raft.lastReplication = time.Now().UnixNano()  // Last replication, in epoch seconds
+
+	// Raft State
+	raft.state = StateFollower
+	raft.currentTerm = 0
+	raft.votedFor = ""
+	raft.leaderId = "" // Who do we think the leader is?
+
+	// Leader State
+	raft.commitIndex = 0
+	raft.lastApplied = 1 // index: 0 -> Op: None
+	raft.nextIndex = map[string]int{}
+	raft.matchIndex = map[string]int{}
+
+	// Components
+	raft.log = newLog()
+	raft.node = maelstrom.NewNode()
+	raft.stateMachine = newKVStore()
+	if err := raft.setupHandlers(); err != nil {
+		return err
+	}
+
+	// random seed
+	rand.Seed(uint64(time.Now().UnixNano()))
+	return nil
+}
+
+func (raft *RaftNode) otherNodes() []string {
+	// All nodes except this one
+	return lo.Filter(raft.node.NodeIDs(), func(nodeId string, _ int) bool {
+		return nodeId != raft.node.ID()
+	})
+}
+
+func (raft *RaftNode) getMatchIndex() map[string]int {
+	// Returns the map of match indices, including an entry for ourselves, based on our log size.
+	clonedMap := maps.Clone(raft.matchIndex)
+	clonedMap[raft.node.ID()] = raft.log.size()
+	return clonedMap
+}
+
+func (raft *RaftNode) brpc(body map[string]interface{}, handler maelstrom.HandlerFunc) {
+	// Broadcast an RPC message To all other nodes, and call handler with each response.
+	log.Printf("in brpc otherNodes %v\n", raft.otherNodes())
+	for _, nodeId := range raft.otherNodes() {
+		raft.node.RPC(nodeId, body, handler)
+	}
+}
+
+func (raft *RaftNode) resetElectionDeadline() {
+	raft.resetElectionDeadlineMu.Lock()
+	defer raft.resetElectionDeadlineMu.Unlock()
+	temp := time.Duration(rand.Float64()+1.0) * time.Second
+	log.Printf("resetElectionDeadline by seconds %d\n", temp)
+	raft.electionDeadline = time.Now().UnixNano() + (temp + raft.electionTimeout).Nanoseconds()
+}
+
+func (raft *RaftNode) resetStepDownDeadline() {
+	raft.resetStepDownDeadlineMu.Lock()
+	defer raft.resetStepDownDeadlineMu.Unlock()
+	// Don't step down for a while.
+	raft.stepDownDeadline = time.Now().UnixNano() + (raft.electionTimeout).Nanoseconds()
+}
+
+func (raft *RaftNode) advanceTerm(term int) {
+	raft.advanceTermMu.Lock()
+	defer raft.advanceTermMu.Unlock()
+	// Advance our Term to `Term`, resetting who we voted for.
+	if raft.currentTerm >= term {
+		panic(fmt.Errorf("Can't go backwards"))
+	}
+
+	raft.currentTerm = term
+	raft.votedFor = ""
+}
+
+func (raft *RaftNode) maybeStepDown(remoteTerm int) {
+	raft.maybeStepDownMu.Lock()
+	defer raft.maybeStepDownMu.Unlock()
+	// If remoteTerm is bigger than ours, advance our term and become a follower.
+	if raft.currentTerm < remoteTerm {
+		log.Printf("Stepping down: remote term %d higher than our term %d", remoteTerm, raft.currentTerm)
+		raft.advanceTerm(remoteTerm)
+		raft.becomeFollower()
+	}
+}
+
+func (raft *RaftNode) requestVotes() {
+	raft.requestVotesMu.Lock()
+	defer raft.requestVotesMu.Unlock()
+	// Request that other nodes vote for us as a leader
+
+	votes := map[string]bool{}
+	term := raft.currentTerm
+
+	// We vote for our-self
+	votes[raft.node.ID()] = true
+
+	handler := func(msg maelstrom.Message) error {
+		raft.requestVoteResHandlerMu.Lock()
+		defer raft.requestVoteResHandlerMu.Unlock()
+		raft.resetStepDownDeadline()
+		var requestVoteResMsgBody RequestVoteResMsgBody
+		if err := json.Unmarshal(msg.Body, &requestVoteResMsgBody); err != nil {
+			panic(err)
+		}
+
+		raft.maybeStepDown(requestVoteResMsgBody.Term)
+
+		if raft.state == StateCandidate &&
+			raft.currentTerm == term &&
+			requestVoteResMsgBody.Term == raft.currentTerm &&
+			requestVoteResMsgBody.VotedGranted {
+
+			// We have a vote for our candidacy
+			votes[msg.Src] = true
+			log.Println("have votes " + fmt.Sprint(votes))
+
+			if majority(len(raft.node.NodeIDs())) <= len(votes) {
+				// We have a majority of votes for this Term
+				if err := raft.becomeLeader(); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	// Broadcast vote request
+	raft.brpc(
+		map[string]interface{}{
+			"type":           MsgTypeRequestVote,
+			"term":           raft.currentTerm,
+			"candidate_id":   raft.node.ID(),
+			"last_log_index": raft.log.size(),
+			"last_log_term":  raft.log.lastTerm(),
+		},
+		handler,
+	)
+}
+
+func (raft *RaftNode) becomeLeader() error {
+	raft.becomeLeaderMu.Lock()
+	defer raft.becomeLeaderMu.Unlock()
+	if raft.state != StateCandidate {
+		return fmt.Errorf("should be a candidate")
+	}
+
+	raft.state = StateLeader
+	raft.leaderId = ""
+	raft.lastReplication = 0 // Start replicating immediately
+
+	// We'll start by trying To replicate our most recent entry
+	raft.matchIndex = map[string]int{}
+	raft.nextIndex = map[string]int{}
+	for _, nodeId := range raft.otherNodes() {
+		raft.nextIndex[nodeId] = raft.log.size() + 1
+		raft.matchIndex[nodeId] = 0
+	}
+	raft.resetStepDownDeadline()
+	log.Println("Became leader for term", raft.currentTerm)
+	return nil
+}
+
+func (raft *RaftNode) becomeCandidate() {
+	raft.becomeCandidateMu.Lock()
+	defer raft.becomeCandidateMu.Unlock()
+	raft.state = StateCandidate
+	raft.advanceTerm(raft.currentTerm + 1)
+	raft.votedFor = raft.node.ID()
+	raft.leaderId = ""
+	raft.resetElectionDeadline()
+	raft.resetStepDownDeadline()
+	log.Println("Became candidate for term", raft.currentTerm)
+	raft.requestVotes()
+}
+
+func (raft *RaftNode) becomeFollower() {
+	raft.becomeFollowerMu.Lock()
+	defer raft.becomeFollowerMu.Unlock()
+
+	raft.state = StateFollower
+	raft.nextIndex = nil
+	raft.matchIndex = nil
+	raft.leaderId = ""
+	raft.resetElectionDeadline()
+	log.Println("Became follower for term", raft.currentTerm)
+}
+
+func (raft *RaftNode) advanceCommitIndex() {
+	// If we're the leader, advance our commit index based on what other nodes match us.
+	raft.advanceCommitIndexMu.Lock()
+	defer raft.advanceCommitIndexMu.Unlock()
+	if raft.state == StateLeader {
+		n := median(maps.Values(raft.getMatchIndex()))
+		if raft.commitIndex < n && raft.log.get(n).Term == raft.currentTerm {
+			log.Printf("commit index now %d\n", n)
+			raft.commitIndex = n
+		}
+	}
+	raft.advanceStateMachine()
+}
+
+func (raft *RaftNode) advanceStateMachine() {
+	// If we have un-applied committed Entries in the log, apply one to the state machine.
+	for raft.lastApplied < raft.commitIndex {
+		// Advance the applied index and apply that Op
+		raft.lastApplied += 1
+		entry := raft.log.get(raft.lastApplied)
+		response := raft.stateMachine.apply(*entry.Op)
+		if raft.state == StateLeader {
+			// We were the leader, let's respond To the Client.
+			if err := raft.node.Reply(entry.Msg, response); err != nil {
+				panic(err)
+			}
+		}
+	}
+}
+
+func newRaftNode() (*RaftNode, error) {
+	raft := RaftNode{}
+	if err := raft.init(); err != nil {
+		return nil, err
+	}
+
+	// periodically try becoming candidate, if election deadline is passed and not a leader.
+	becomeCandidateTicker := time.NewTicker(100 * time.Millisecond)
+	go func() {
+		for {
+			select {
+			case <-becomeCandidateTicker.C:
+				r := rand.Int63n(100)
+				time.Sleep(time.Duration(r) * time.Millisecond)
+				if raft.electionDeadline < time.Now().UnixNano() {
+					if raft.state != StateLeader {
+						raft.becomeCandidate()
+					} else {
+						raft.resetElectionDeadline()
+					}
+				}
+			}
+		}
+	}()
+
+	// periodically step down if no acknowledgments are received
+	leaderStepDownTicker := time.NewTicker(100 * time.Millisecond)
+	go func() {
+		for {
+			select {
+			case <-leaderStepDownTicker.C:
+				if raft.state == StateLeader && raft.stepDownDeadline < time.Now().UnixNano() {
+					log.Println("Stepping down: haven't received any acks recently")
+					raft.becomeFollower()
+				}
+			}
+		}
+	}()
+
+	// periodically replicate log
+	replicateLogTicker := time.NewTicker(raft.minReplicationInterval)
+	go func() {
+		for {
+			select {
+			case <-replicateLogTicker.C:
+				if err := raft.replicateLog(); err != nil {
+					panic(err)
+				}
+			}
+		}
+	}()
+
+	return &raft, nil
+}

--- a/demo/go/cmd/maelstrom-raft/replicate_log.go
+++ b/demo/go/cmd/maelstrom-raft/replicate_log.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	maelstrom "github.com/jepsen-io/maelstrom/demo/go"
+	"log"
+	"time"
+)
+
+func (raft *RaftNode) replicateLog() error {
+	raft.replicateLogMu.Lock()
+	defer raft.replicateLogMu.Unlock()
+
+	// If we're the leader, replicate unacknowledged log entries to followers. Also serves as a heartbeat.
+
+	// How long has it been since we replicated?
+	elapsedTime := time.Duration(time.Now().UnixNano() - raft.lastReplication)
+	// We'll set this to true if we replicate to anyone
+	replicated := false
+	// We'll need this to make sure we process responses in *this* term
+	term := raft.currentTerm
+
+	if raft.state == StateLeader && raft.minReplicationInterval < elapsedTime {
+		// We're a leader, and enough time elapsed
+		for _, nodeId := range raft.otherNodes() {
+			// What entries should we send this node?
+			ni := raft.nextIndex[nodeId]
+			entries := raft.log.fromIndex(ni)
+
+			if 0 < len(entries) || raft.heartbeatInterval < elapsedTime {
+				log.Printf("Replicating %d to %s\n", ni, nodeId)
+				replicated = true
+
+				// closure
+				_ni := ni
+				_entries := append([]Entry{}, entries...)
+				_nodeId := nodeId
+
+				appendEntriesResHandler := func(res maelstrom.Message) error {
+					raft.appendEntriesResMu.Lock()
+					defer raft.appendEntriesResMu.Unlock()
+
+					var appendEntriesResMsgBody AppendEntriesResMsgBody
+					err := json.Unmarshal(res.Body, &appendEntriesResMsgBody)
+					if err != nil {
+						panic(err)
+					}
+
+					raft.maybeStepDown(appendEntriesResMsgBody.Term)
+					if raft.state == StateLeader && term == raft.currentTerm {
+						raft.resetStepDownDeadline()
+						if appendEntriesResMsgBody.Success {
+							// Excellent, these entries are now replicated!
+							raft.nextIndex[_nodeId] = max(raft.nextIndex[_nodeId], _ni+len(_entries))
+							raft.matchIndex[_nodeId] = max(raft.matchIndex[_nodeId], _ni+len(_entries)-1)
+							log.Printf("node %s entries %d ni %d\n", _nodeId, len(_entries), ni)
+							log.Println("next index:" + fmt.Sprint(raft.nextIndex))
+							raft.advanceCommitIndex()
+						} else {
+							raft.nextIndex[_nodeId] -= 1
+						}
+					}
+
+					return nil
+				}
+
+				if err := raft.node.RPC(
+					nodeId,
+					&AppendEntriesMsgBody{
+						Type:         MsgTypeAppendEntries,
+						Term:         raft.currentTerm,
+						LeaderId:     raft.node.ID(),
+						PrevLogIndex: ni - 1,
+						PrevLogTerm:  raft.log.get(ni - 1).Term,
+						Entries:      entries,
+						LeaderCommit: raft.commitIndex,
+					},
+					appendEntriesResHandler,
+				); err != nil {
+					panic(err)
+				}
+			}
+		}
+	}
+
+	if replicated {
+		raft.lastReplication = time.Now().UnixNano()
+	}
+	return nil
+}

--- a/demo/go/cmd/maelstrom-raft/request_structs.go
+++ b/demo/go/cmd/maelstrom-raft/request_structs.go
@@ -1,0 +1,53 @@
+package main
+
+type ReadMsgBody struct {
+	Type   MsgType `mapstructure:"type" json:"type"`
+	MsgId  int     `mapstructure:"msg_id" json:"msg_id"`
+	Key    int     `mapstructure:"key" json:"key"`
+	Client string  `mapstructure:"client" json:"client"`
+}
+
+type WriteMsgBody struct {
+	Type   MsgType `mapstructure:"type" json:"type"`
+	MsgId  int     `mapstructure:"msg_id" json:"msg_id"`
+	Key    int     `mapstructure:"key" json:"key"`
+	Value  int     `mapstructure:"value" json:"value"`
+	Client string  `mapstructure:"client" json:"client"`
+}
+
+type CasMsgBody struct {
+	Type   MsgType `mapstructure:"type" json:"type"`
+	MsgId  int     `mapstructure:"msg_id" json:"msg_id"`
+	Key    int     `mapstructure:"key" json:"key"`
+	From   int     `mapstructure:"from" json:"from"`
+	To     int     `mapstructure:"to" json:"to"`
+	Client string  `mapstructure:"client" json:"client"`
+}
+
+type AppendEntriesMsgBody struct {
+	Type         MsgType `mapstructure:"type" json:"type"`
+	MsgId        int     `mapstructure:"msg_id" json:"msg_id"`
+	Term         int     `mapstructure:"term" json:"term"`
+	LeaderId     string  `mapstructure:"leader_id" json:"leader_id"`
+	PrevLogIndex int     `mapstructure:"prev_log_index" json:"prev_log_index"`
+	PrevLogTerm  int     `mapstructure:"prev_log_term" json:"prev_log_term"`
+	Entries      []Entry `mapstructure:"entries" json:"entries"`
+	LeaderCommit int     `mapstructure:"leader_commit" json:"leader_commit"`
+}
+
+func (res *AppendEntriesMsgBody) SetMsgId(msgId int) {
+	res.MsgId = msgId
+}
+
+type RequestVoteMsgBody struct {
+	Type         MsgType `mapstructure:"type" json:"type"`
+	MsgId        int     `mapstructure:"msg_id" json:"msg_id"`
+	Term         int     `mapstructure:"term" json:"term"`
+	CandidateId  string  `mapstructure:"candidate_id" json:"candidate_id"`
+	LastLogIndex int     `mapstructure:"last_log_index" json:"last_log_index"`
+	LastLogTerm  int     `mapstructure:"last_log_term" json:"last_log_term"`
+}
+
+func (res *RequestVoteMsgBody) SetMsgId(msgId int) {
+	res.MsgId = msgId
+}

--- a/demo/go/cmd/maelstrom-raft/response_structs.go
+++ b/demo/go/cmd/maelstrom-raft/response_structs.go
@@ -1,0 +1,38 @@
+package main
+
+type ReadOkMsgBody struct {
+	Type      MsgType `mapstructure:"type" json:"type"`
+	Value     int     `mapstructure:"value" json:"value"`
+	InReplyTo int     `mapstructure:"in_reply_to" json:"in_reply_to"`
+}
+
+type WriteOkMsgBody struct {
+	Type      MsgType `mapstructure:"type" json:"type"`
+	InReplyTo int     `mapstructure:"in_reply_to" json:"in_reply_to"`
+}
+
+type CasOkMsgBody struct {
+	Type      MsgType `mapstructure:"type" json:"type"`
+	InReplyTo int     `mapstructure:"in_reply_to" json:"in_reply_to"`
+}
+
+type ErrorMsgBody struct {
+	Type      MsgType `mapstructure:"type" json:"type"`
+	Code      ErrCode `mapstructure:"code" json:"code"`
+	Text      string  `mapstructure:"text" json:"text"`
+	InReplyTo int     `mapstructure:"in_reply_to" json:"in_reply_to"`
+}
+
+type RequestVoteResMsgBody struct {
+	Type         MsgType `mapstructure:"type" json:"type"`
+	Term         int     `mapstructure:"term" json:"term"`
+	VotedGranted bool    `mapstructure:"vote_granted" json:"vote_granted"`
+	InReplyTo    int     `mapstructure:"in_reply_to" json:"in_reply_to"`
+}
+
+type AppendEntriesResMsgBody struct {
+	Type      MsgType `mapstructure:"type" json:"type"`
+	Term      int     `mapstructure:"term" json:"term"`
+	Success   bool    `mapstructure:"success" json:"success"`
+	InReplyTo int     `mapstructure:"in_reply_to" json:"in_reply_to"`
+}

--- a/demo/go/cmd/maelstrom-raft/structs.go
+++ b/demo/go/cmd/maelstrom-raft/structs.go
@@ -1,0 +1,54 @@
+package main
+
+import maelstrom "github.com/jepsen-io/maelstrom/demo/go"
+
+type Entry struct {
+	Term int
+	Op   *Operation
+	Msg  maelstrom.Message
+}
+
+type Operation struct {
+	// all op
+	Type   MsgType
+	MsgId  int
+	Key    int
+	Client string
+
+	// for write op
+	Value int
+
+	// for cas op
+	From int
+	To   int
+}
+
+type MsgType string
+
+const (
+	MsgTypeRead                MsgType = "read"
+	MsgTypeReadOk              MsgType = "read_ok"
+	MsgTypeWrite               MsgType = "write"
+	MsgTypeWriteOk             MsgType = "write_ok"
+	MsgTypeCas                 MsgType = "cas"
+	MsgTypeCasOk               MsgType = "cas_ok"
+	MsgTypeRequestVote         MsgType = "request_vote"
+	MsgTypeRequestVoteResult   MsgType = "request_vote_res"
+	MsgTypeAppendEntries       MsgType = "append_entries"
+	MsgTypeAppendEntriesResult MsgType = "append_entries_res"
+	MsgTypeError               MsgType = "error"
+)
+
+type ErrCode int
+
+const (
+	ErrCodeTemporarilyUnavailable ErrCode = 11
+	ErrCodeKeyDoesNotExist        ErrCode = 20
+	ErrCodePreconditionFailed     ErrCode = 22
+)
+
+const (
+	ErrNotLeader      = "not a leader"
+	ErrTxtNotFound    = "not found"
+	ErrExpectedButHad = "expected %d but had %d"
+)

--- a/demo/go/cmd/maelstrom-raft/utils.go
+++ b/demo/go/cmd/maelstrom-raft/utils.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"log"
+	"math"
+	"sort"
+)
+
+func majority(n int) int {
+	log.Println("math.Floor(float64(n)/2.0) + 1", math.Floor(float64(n)/2.0)+1)
+	return int(math.Floor(float64(n)/2.0) + 1)
+}
+
+func median(keys []int) int {
+	sort.Ints(keys)
+	return keys[len(keys)-majority(len(keys))]
+}

--- a/demo/go/go.mod
+++ b/demo/go/go.mod
@@ -1,3 +1,3 @@
 module github.com/jepsen-io/maelstrom/demo/go
 
-go 1.19
+go 1.21.0


### PR DESCRIPTION
What 
- This PR introduces a Raft consensus algorithm demo implemented in Go, closely following the existing demo using [Maelstrom's Ruby demo](https://github.com/jepsen-io/maelstrom/tree/main/doc/06-raft).

Testing

```
(cd demo/go/cmd/maelstrom-raft/ && go build) && (./maelstrom test -w lin-kv --bin demo/go/cmd/maelstrom-raft/maelstrom-raft --node-count 3 --concurrency 4n --rate 30 --time-limit 60 --nemesis partition --nemesis-interval 10 --test-count 2)
```

Results

![image](https://github.com/jepsen-io/maelstrom/assets/11707302/01d2db09-541d-49ab-8beb-703e3cbde807)

![image](https://github.com/jepsen-io/maelstrom/assets/11707302/d769a7fe-16e2-4a2a-9475-877e29bd2ac9)
