### PR TITLE
Fix hashbang in JS examples

### DIFF
--- a/demo/js/crdt_gset.js
+++ b/demo/js/crdt_gset.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 // A CRDT grow-only set
 var node = require('./node');

--- a/demo/js/crdt_pn_counter.js
+++ b/demo/js/crdt_pn_counter.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 // A CRDT PN-counter
 var node = require('./node');

--- a/demo/js/echo.js
+++ b/demo/js/echo.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 // A basic echo server
 var node = require('./node');

--- a/demo/js/echo_minimal.js
+++ b/demo/js/echo_minimal.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 var readline = require('readline');
 var rl = readline.createInterface({

--- a/demo/js/gossip.js
+++ b/demo/js/gossip.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 // A gossip system which supports the Maelstrom broadcast workload
 var node = require('./node');

--- a/demo/js/multi_key_txn.js
+++ b/demo/js/multi_key_txn.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 // A simple list-append transaction service which stores data in multiple
 // lww-kv thunks referenced by a single root map in lin-kv.

--- a/demo/js/node.js
+++ b/demo/js/node.js
@@ -1,5 +1,3 @@
-#!/usr/bin/node
-
 // The node object provides support for reading messages from STDIN, writing
 // them to STDOUT, keeping track of basic state, writing pluggable handlers for
 // client RPC requests, and sending our own RPCs.

--- a/demo/js/single_key_txn.js
+++ b/demo/js/single_key_txn.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 // A simple list-append transaction service which stores data in a single key
 // in lin-kv.


### PR DESCRIPTION
There is no `/usr/bin/node` in recent versions of macOS so it's safer to use `/usr/bin/env node` instead. Also removed hashbang from `node.js` implementation since it's not needed.

Possibly related to #85. 