### PR TITLE
Add lin-kv-only workload and 3 single-decree paxos services

### DIFF
--- a/src/maelstrom/core.clj
+++ b/src/maelstrom/core.clj
@@ -20,6 +20,7 @@
                                 [g-counter :as g-counter]
                                 [pn-counter :as pn-counter]
                                 [lin-kv :as lin-kv]
+                                [lin-kv-only :as lin-kv-only]
                                 [txn-list-append :as txn-list-append]
                                 [txn-rw-register :as txn-rw-register]
                                 [unique-ids :as unique-ids]]
@@ -42,6 +43,7 @@
    :g-counter       g-counter/workload
    :pn-counter      pn-counter/workload
    :lin-kv          lin-kv/workload
+   :lin-kv-only     lin-kv-only/workload
    :txn-list-append txn-list-append/workload
    :txn-rw-register txn-rw-register/workload
    :unique-ids      unique-ids/workload})
@@ -110,6 +112,7 @@
    {:workload :pn-counter,  :bin "demo/ruby/pn_counter.rb"}
    {:workload :lin-kv,      :bin "demo/ruby/raft.rb", :concurrency 10}
    {:workload :lin-kv       :bin "demo/ruby/lin_kv_proxy.rb", :concurrency 10}
+   {:workload :lin-kv-only, :bin "demo/ruby/lin_kv_proxy.rb", :concurrency 10}
    {:workload     :txn-list-append
     :bin          "demo/ruby/datomic_list_append.rb"}
    {:workload     :txn-rw-register

--- a/src/maelstrom/workload/lin_kv_only.clj
+++ b/src/maelstrom/workload/lin_kv_only.clj
@@ -1,0 +1,109 @@
+(ns maelstrom.workload.lin-kv-only
+  "A workload for a linearizable key-value store that consists only of reads and writes."
+  (:refer-clojure :exclude [read])
+  (:require [maelstrom [client :as c]
+                       [net :as net]]
+            [jepsen [client :as client]
+                    [checker :as checker]
+                    [generator :as gen]
+                    [independent :as independent]]
+            [jepsen.checker.timeline :as timeline]
+            [knossos.model :as model]
+            [schema.core :as s]))
+
+(c/defrpc read
+  "Reads the current value of a single key. Clients send a `read` request with
+  the key they'd like to observe, and expect a response with the current
+  `value` of that key."
+  {:type  (s/eq "read")
+   :key   s/Any}
+  {:type  (s/eq "read_ok")
+   :value s/Any})
+
+(c/defrpc write!
+  "Blindly overwrites the value of a key. Creates keys if they do not presently
+  exist. Servers should respond with a `read_ok` response once the write is
+  complete."
+  {:type (s/eq "write")
+   :key  s/Any
+   :value s/Any}
+  {:type (s/eq "write_ok")})
+
+(defn client
+  "Construct a linearizable key-value client for the given network"
+  ([net]
+   (client net nil nil))
+  ([net conn node]
+   (reify client/Client
+     (open! [this test node]
+       (client net (c/open! net) node))
+
+     (setup! [this test])
+
+     (invoke! [_ test op]
+       (c/with-errors op #{:read}
+         (let [[k v]   (:value op)
+               timeout (max (* 10 (:mean (:latency test))) 1000)]
+           (case (:f op)
+             :read (let [res (read conn node {:key k} timeout)
+                         v (:value res)]
+                     (assoc op
+                            :type  :ok
+                            :value (independent/tuple k v)))
+
+             :write (let [res (write! conn node {:key k, :value v} timeout)]
+                      (assoc op :type :ok))))))
+
+     (teardown! [_ test])
+
+     (close! [_ test]
+       (c/close! conn))
+
+     client/Reusable
+     (reusable? [this test]
+       true))))
+
+(defn w   [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
+(defn r   [_ _] {:type :invoke, :f :read})
+
+(defn test
+  "A partial test, including a generator, model, and checker. You'll need to
+  provide a client. Options:
+
+    :nodes            A set of nodes you're going to operate on. We only care
+                      about the count, so we can figure out how many workers
+                      to use per key.
+    :model            A model for checking. Default is (model/cas-register).
+    :per-key-limit    Maximum number of ops per key.
+    :process-limit    Maximum number of processes that can interact with a
+                      given key. Default 20."
+  [opts]
+  {:checker (independent/checker
+              (checker/compose
+               {:linearizable (checker/linearizable
+                                {:model (:model opts (model/cas-register))})
+                :timeline     (timeline/html)}))
+   :generator (let [n (count (:nodes opts))]
+                (independent/concurrent-generator
+                  (* 2 n)
+                  (range)
+                  (fn [k]
+                    (cond->> (gen/reserve n r w)
+                      ; We randomize the limit a bit so that over time, keys
+                      ; become misaligned, which prevents us from lining up
+                      ; on Significant Event Boundaries.
+                      (:per-key-limit opts)
+                      (gen/limit (* (+ (rand 0.1) 0.9)
+                                    (:per-key-limit opts 20)))
+
+                      true
+                      (gen/process-limit (:process-limit opts 20))))))})
+
+(defn workload
+  "Constructs a workload for linearizable registers that consists only of reads
+  and writes, given option from the CLI test constructor:
+
+      {:net     A Maelstrom network}"
+  [opts]
+  (-> (test {:nodes (:nodes opts)})
+      (assoc :client (client (:net opts)))))


### PR DESCRIPTION
NOTICE: I am not fully sure if it makes sense, and if anyone will find it useful. I also did not discuss it with anyone yet if they are interested in it. 

This work appeared as my desire to add 7th task to https://fly.io/dist-sys/ challenge about implementing existing KV workload in the simplest possible way without any leader-heavy consensus and give people an opportunity to learn something about lin KV storages and about consensus algorithms.

To simplify the effort, I planned people would need to implement linearizable KVC operations first with the external consensus oracle represented by single-decree Paxos, and only then they would be having a chance to implement the Paxos itself on top of the stable and correct code.

This patch adds:

1. lin-kv-only workload is the same workload as lin-kv besides it does not issue :cas commands to simplify playground for people who wants to try to implement and play with linearizable KV storage implementations that are so simple that does not use Leader-based consensus, Consensus Log, Key versions.

   `$ lein run -- test -w lin-kv-only --bin demo/ruby/lin_kv_sdp.rb --time-limit 10 --node-count 3 --rate 10 --concurrency 10 --key-count 1 --latency 200 --latency-dist uniform`

2. raw-con, sdp-con and msdp-con services that represent single-decree consensus oracles ([single-decree paxos](https://en.wikipedia.org/wiki/Paxos_(computer_science)#Basic_Paxos) variants) to give people opportunity to implement linearizable KV storage given the simplest algorithms available. Besides that, even simple Paxos can be non-trivial to implement correctly; there are different nuances of an implementation of the linearizable-read-op with leaderless Paxos. I wanted to allow them to focus on this part first. This also pushes people to abstract their consensus implementations as much as possible and focus on one thing at a time.

Consensus services are represented as 2 stage state-machines:

1. Proposal stage. At this stage, you can propose a value to be later decided. This is equivalent to Prepare-Promise part where a proposer tries to obtain votes majority for his right to propose a new value.

2. Deciding stage. At this stage, you ask acceptors to accept a proposed value. You don't know what value will be decided - it can be yours or others or one previously promised.

Once the value is decided, no more proposals and decisions are allowed. To use the consensus oracle one more time, you can reset it by sending the reset command.

`msdp-con` is a variant of `sdp-con` (basic-paxos) that allows you to build a distributed log on top of it. It allows you to decide a value for a slot `<i>` if nothing was decided for a slot `<j> | j >= i`.

This `msdp-con` must be useful for building full KV storage with CAS.

Lein
===

```
$ lein repl
(use 'maelstrom.service :reload)(handle (first (handle (first (handle (sd-paxos) {:body {:type "propose" :value 1}})) {:body {:type "propose" :value 2}})) {:body {:type "decide"}})
(linearizable(sd-paxos))
(use 'maelstrom.service :reload)
(def a (linearizable(sd-paxos)))
(handle! a {:body {:type "propose" :value 1}})
(handle! a {:body {:type "propose" :value 2}})
(handle! a {:body {:type "propose" :value 3}})
a
=> #maelstrom.service.Linearizable{:state #object[... {:status :ready, :val #maelstrom.service.SDPaxos{:m (3 2 1)}}]}
(handle! a {:body {:type "decide"}})
=> {:type "decide_ok", :value 2}
a
=> ... SDPaxos{:log [2] :m ()}}

(use 'maelstrom.service :reload)(handle (first (handle (first (handle (msd-paxos) {:body {:type "propose" :value 1 :i 1}})) {:body {:type "propose" :value 2 :i 1}})) {:body {:type "decide"}})
(def a (linearizable(msd-paxos)))
(handle! a {:body {:type "propose" :value 1 :i 1}})
(handle! a {:body {:type "propose" :value 2 :i 1}})
(handle! a {:body {:type "decide"}})
(handle! a {:body {:type "propose" :value 3 :i 2}})
(handle! a {:body {:type "propose" :value 4 :i 2}})
(handle! a {:body {:type "decide"}})
```

Usage
===

sdp-con:

```
{ type: "propose", value: 1 }
{ type: "propose_ok" }
{ type: "propose", value: 2 }
{ type: "propose_ok" }

{ type: "decide" }
{ type: "decide_ok", value: 2 }

{ type: "reset" }
{ type: "reset_ok" }
```

msdp-con:

```
{ type: "propose", value: 1, i: 1 }
{ type: "propose_ok" }
{ type: "propose", value: 2, i: 1 }
{ type: "propose_ok" }

{ type: "decide" }
{ type: "decide_ok", value: 2, i: 1 }
```