### PR TITLE
Add lin-kv-reconfig workload with dynamic cluster membership

### DIFF
--- a/demo/python/raft.py
+++ b/demo/python/raft.py
@@ -205,7 +205,9 @@ class RaftNode():
 
         # Node & cluster IDS
         self.node_id = None     # Our node ID
-        self.node_ids = None    # List of all node IDs
+        self.initial_node_ids = None  # Initial cluster membership from init
+        self.node_ids = None    # Current cluster membership (updated immediately
+                                # when config entries are appended, not on commit)
 
         # Raft state
         self.state = 'nascent'  # One of nascent, follower, candidate, or leader
@@ -226,10 +228,45 @@ class RaftNode():
         self.state_machine = KVStore()
         self.setup_handlers()
 
+    def is_member(self):
+        """Are we currently a member of the cluster?"""
+        return self.node_ids is not None and self.node_id in self.node_ids
+
+    def has_pending_config(self):
+        """Is there a config change entry that hasn't been applied yet?
+        We only allow one config change at a time."""
+        for i in range(self.last_applied + 1, self.log.size() + 1):
+            op = self.log.get(i).get('op')
+            if op and op.get('type') in ('add_member', 'remove_member'):
+                return True
+        return False
+
+    def has_committed_in_current_term(self):
+        """Has any entry from the current term been committed?
+        Used to enforce the no-op guard: a leader must commit an entry in its
+        own term before accepting config changes (Raft thesis bug fix)."""
+        return self.commit_index >= 1 and \
+               self.log.get(self.commit_index)['term'] == self.current_term
+
+    def rebuild_config(self):
+        """Reconstruct node_ids from initial config + all config entries in the
+        log. Called after log truncation to handle reverted config changes."""
+        self.node_ids = list(self.initial_node_ids)
+        for i in range(2, self.log.size() + 1):
+            op = self.log.get(i).get('op')
+            if op and op.get('type') == 'add_member':
+                if op['node_id'] not in self.node_ids:
+                    self.node_ids.append(op['node_id'])
+            elif op and op.get('type') == 'remove_member':
+                if op['node_id'] in self.node_ids:
+                    self.node_ids.remove(op['node_id'])
+        log('Config rebuilt to:', self.node_ids)
+
     def other_nodes(self):
-        """All nodes except this one."""
+        """All nodes in the current config except this one."""
         nodes = list(self.node_ids)
-        nodes.remove(self.node_id)
+        if self.node_id in nodes:
+            nodes.remove(self.node_id)
         return nodes
 
     def match_index(self):
@@ -342,6 +379,11 @@ class RaftNode():
         self.reset_step_down_deadline()
         log('Became leader for term', self.current_term)
 
+        # Append a no-op entry. Once committed, this guarantees we know the
+        # latest committed config before accepting config changes. This is
+        # the fix for the Raft thesis single-server membership change bug.
+        self.log.append([{'term': self.current_term, 'op': None}])
+
     # Actions for all nodes
 
     def advance_state_machine(self):
@@ -349,10 +391,35 @@ class RaftNode():
         if self.last_applied < self.commit_index:
             # Advance the applied index and apply that op
             self.last_applied += 1
-            res = self.state_machine.apply(self.log.get(self.last_applied)['op'])
-            if self.state == 'leader':
-                # We were the leader, let's respond to the client.
-                self.net.send(res['dest'], res['body'])
+            entry = self.log.get(self.last_applied)
+            op = entry['op']
+
+            if op is None:
+                # No-op entry, skip
+                pass
+            elif op['type'] in ('add_member', 'remove_member'):
+                # Config already took effect when appended; just respond
+                if self.state == 'leader' and 'client' in op:
+                    self.net.send(op['client'], {
+                        'type': op['type'] + '_ok',
+                        'in_reply_to': op['msg_id']
+                    })
+                # Clean up leader state for removed node
+                if op['type'] == 'remove_member' and self.state == 'leader':
+                    self.next_index.pop(op['node_id'], None)
+                    self._match_index.pop(op['node_id'], None)
+                # Step down if we committed our own removal
+                if op['type'] == 'remove_member' and \
+                        op['node_id'] == self.node_id and \
+                        self.state == 'leader':
+                    log('Committed own removal, stepping down')
+                    self.become_follower()
+            else:
+                # KV operation
+                res = self.state_machine.apply(op)
+                if self.state == 'leader':
+                    # We were the leader, let's respond to the client.
+                    self.net.send(res['dest'], res['body'])
 
         # We did something!
         return True
@@ -362,11 +429,12 @@ class RaftNode():
     def election(self):
         """If it's been long enough, trigger a leader election."""
         if self.election_deadline < time.time():
-            if self.state == 'follower' or self.state == 'candidate':
+            if (self.state == 'follower' or self.state == 'candidate') \
+                    and self.is_member():
                 # Let's go!
                 self.become_candidate()
             else:
-                # We're a leader, or initializing; sleep again
+                # We're a leader, not a member, or initializing; sleep again
                 self.reset_election_deadline()
             return True
 
@@ -382,7 +450,12 @@ class RaftNode():
     def advance_commit_index(self):
         """If we're the leader, advance our commit index based on what other nodes match us."""
         if self.state == 'leader':
-            n = median(self.match_index().values())
+            # Only count nodes in the current config for majority.
+            # This handles the case where a leader has removed itself:
+            # it should not count its own vote.
+            mi = {k: v for k, v in self.match_index().items()
+                   if k in self.node_ids}
+            n = median(mi.values())
             if self.commit_index < n and self.log.get(n)['term'] == self.current_term:
                 log("Commit index now", n)
                 self.commit_index = n
@@ -400,7 +473,8 @@ class RaftNode():
 
         if self.state == 'leader' and self.min_replication_interval < elapsed_time:
             # We're a leader, and enough time elapsed
-            for node in self.other_nodes():
+            # Replicate to all nodes we're tracking (includes pending additions)
+            for node in list(self.next_index.keys()):
                 # What entries should we send this node?
                 ni = self.next_index[node]
                 entries = self.log.from_index(ni)
@@ -418,6 +492,8 @@ class RaftNode():
                         self.maybe_step_down(body['term'])
                         if self.state == 'leader' and term == self.current_term:
                             self.reset_step_down_deadline()
+                            if _node not in self.next_index:
+                                return  # Node was removed
                             if body['success']:
                                 self.next_index[_node] = \
                                         max(self.next_index[_node], _ni + len(_entries))
@@ -456,11 +532,15 @@ class RaftNode():
 
             body = msg['body']
             self.set_node_id(body['node_id'])
-            self.node_ids = body['node_ids']
+            # Use initial_member_ids if present (for lin-kv-reconfig workload),
+            # otherwise fall back to node_ids (standard behavior).
+            self.initial_node_ids = list(
+                body.get('initial_member_ids', body['node_ids']))
+            self.node_ids = list(self.initial_node_ids)
 
             self.become_follower()
 
-            log('I am:', self.node_id)
+            log('I am:', self.node_id, 'members:', self.node_ids)
             self.net.reply(msg, {'type': 'init_ok'})
 
         self.net.on('init', raft_init)
@@ -538,6 +618,11 @@ class RaftNode():
             self.log.truncate(body['prev_log_index'])
             self.log.append(body['entries'])
 
+            # Rebuild config from log in case truncation reverted config
+            # entries or new entries contain config changes. Config takes
+            # effect immediately on append.
+            self.rebuild_config()
+
             # Advance commit pointer
             if self.commit_index < body['leader_commit']:
                 self.commit_index = min(body['leader_commit'], self.log.size(),)
@@ -550,7 +635,13 @@ class RaftNode():
 
         # Handle client KV requests
         def kv_req(msg):
-            if self.state == 'leader':
+            if not self.is_member():
+                self.net.reply(msg, {
+                    'type': 'error',
+                    'code': 40,
+                    'text': 'not a member'
+                    })
+            elif self.state == 'leader':
                 # Record who we should tell about the completion of this op
                 op = msg['body']
                 op['client'] = msg['src']
@@ -569,6 +660,62 @@ class RaftNode():
         self.net.on('read', kv_req)
         self.net.on('write', kv_req)
         self.net.on('cas', kv_req)
+
+        # Handle membership change requests
+        def config_change_req(msg):
+            if not self.is_member():
+                self.net.reply(msg, {
+                    'type': 'error',
+                    'code': 11,
+                    'text': 'not a member'
+                    })
+            elif self.state != 'leader':
+                if self.leader:
+                    # Proxy to leader
+                    msg['dest'] = self.leader
+                    self.net.send_msg(msg)
+                else:
+                    self.net.reply(msg, {
+                        'type': 'error',
+                        'code': 11,
+                        'text': 'not a leader'
+                        })
+            elif not self.has_committed_in_current_term():
+                # Raft thesis bug fix: reject config changes until we've
+                # committed an entry in our current term (the no-op).
+                self.net.reply(msg, {
+                    'type': 'error',
+                    'code': 11,
+                    'text': 'no entry committed in current term yet'
+                    })
+            elif self.has_pending_config():
+                self.net.reply(msg, {
+                    'type': 'error',
+                    'code': 11,
+                    'text': 'config change already pending'
+                    })
+            else:
+                op = msg['body']
+                op['client'] = msg['src']
+                self.log.append([{'term': self.current_term, 'op': op}])
+
+                # Config takes effect immediately on append
+                if op['type'] == 'add_member':
+                    if op['node_id'] not in self.node_ids:
+                        self.node_ids.append(op['node_id'])
+                    # Start replicating to the new node
+                    if op['node_id'] not in self.next_index:
+                        self.next_index[op['node_id']] = self.log.size() + 1
+                        self._match_index[op['node_id']] = 0
+                elif op['type'] == 'remove_member':
+                    if op['node_id'] in self.node_ids:
+                        self.node_ids.remove(op['node_id'])
+
+                log('Proposed config change:', op['type'], op['node_id'],
+                    'config now:', self.node_ids)
+
+        self.net.on('add_member', config_change_req)
+        self.net.on('remove_member', config_change_req)
 
     def main(self):
         """Mainloop."""

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -165,3 +165,4 @@ The following table lists all of Maelstrom's defined errors.
 | 21 | key-already-exists | ✓ | The client requested the creation of a key which already exists, and the server will not overwrite it. |
 | 22 | precondition-failed | ✓ | The requested operation expected some conditions to hold, and those conditions were not met. For instance, a compare-and-set operation might assert that the value of a key is currently 5; if the value is 3, the server would return `precondition-failed`. |
 | 30 | txn-conflict | ✓ | The requested transaction has been aborted because of a conflict with another transaction. Servers need not return this error on every conflict: they may choose to retry automatically instead. |
+| 40 | not-a-member | ✓ | The node is not currently a member of the cluster, and therefore cannot process the request. Used by the lin-kv-reconfig workload, where cluster membership changes dynamically via add_member and remove_member RPCs. |

--- a/doc/workloads.md
+++ b/doc/workloads.md
@@ -56,7 +56,9 @@ Request:
 Response:
 
 ```clj
-{:type (eq "topology_ok"), {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "topology_ok"),
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 
@@ -74,7 +76,9 @@ Request:
 Response:
 
 ```clj
-{:type (eq "broadcast_ok"), {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "broadcast_ok"),
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 
@@ -93,7 +97,7 @@ Response:
 ```clj
 {:type (eq "read_ok"),
  :messages [Any],
- {:k :msg_id} Int,
+ #schema.core.OptionalKey{:k :msg_id} Int,
  :in_reply_to Int}
 ```
 
@@ -119,7 +123,10 @@ Request:
 Response:
 
 ```clj
-{:type (eq "echo_ok"), :echo Any, {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "echo_ok"),
+ :echo Any,
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 
@@ -146,7 +153,9 @@ Request:
 Response:
 
 ```clj
-{:type (eq "add_ok"), {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "add_ok"),
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 
@@ -165,7 +174,10 @@ Request:
 Response:
 
 ```clj
-{:type (eq "read_ok"), :value Int, {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "read_ok"),
+ :value Int,
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 
@@ -189,7 +201,9 @@ Request:
 Response:
 
 ```clj
-{:type (eq "add_ok"), {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "add_ok"),
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 
@@ -208,7 +222,10 @@ Request:
 Response:
 
 ```clj
-{:type (eq "read_ok"), :value [Any], {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "read_ok"),
+ :value [Any],
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 
@@ -306,7 +323,7 @@ Response:
 ```clj
 {:type (eq "send_ok"),
  :offset (named Int "offset"),
- {:k :msg_id} Int,
+ #schema.core.OptionalKey{:k :msg_id} Int,
  :in_reply_to Int}
 ```
 
@@ -352,9 +369,13 @@ Response:
 {:type (eq "poll_ok"),
  :msgs
  {(named Str "key")
-  [[{:schema (named Int "offset"), :optional? false, :name "offset"}
-    {:schema (named Any "msg"), :optional? false, :name "msg"}]]},
- {:k :msg_id} Int,
+  [[#schema.core.One{:schema (named Int "offset"),
+                     :optional? false,
+                     :name "offset"}
+    #schema.core.One{:schema (named Any "msg"),
+                     :optional? false,
+                     :name "msg"}]]},
+ #schema.core.OptionalKey{:k :msg_id} Int,
  :in_reply_to Int}
 ```
 
@@ -385,7 +406,9 @@ Request:
 Response:
 
 ```clj
-{:type (eq "commit_offsets_ok"), {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "commit_offsets_ok"),
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 
@@ -409,7 +432,7 @@ Response:
 ```clj
 {:type (eq "list_committed_offsets_ok"),
  :offsets {(named Str "key") (named Int "offset")},
- {:k :msg_id} Int,
+ #schema.core.OptionalKey{:k :msg_id} Int,
  :in_reply_to Int}
 ```
 
@@ -434,14 +457,17 @@ Request:
 Response:
 
 ```clj
-{:type (eq "read_ok"), :value Any, {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "read_ok"),
+ :value Any,
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 
 ### RPC: Write! 
 
 Blindly overwrites the value of a key. Creates keys if they do not presently
-exist. Servers should respond with a `read_ok` response once the write is
+exist. Servers should respond with a `write_ok` response once the write is
 complete. 
 
 Request:
@@ -453,7 +479,9 @@ Request:
 Response:
 
 ```clj
-{:type (eq "write_ok"), {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "write_ok"),
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 
@@ -472,10 +500,10 @@ Request:
 Response:
 
 ```clj
-{:type (eq "cas_ok"), {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "cas_ok"),
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
-
-
 
 ## Workload: Lin-kv-reconfig 
 
@@ -515,7 +543,9 @@ Request:
 Response:
 
 ```clj
-{:type (eq "add_member_ok"), {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "add_member_ok"),
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 
@@ -536,9 +566,10 @@ Request:
 Response:
 
 ```clj
-{:type (eq "remove_member_ok"), {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "remove_member_ok"),
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
-
 
 
 ## Workload: Pn-counter 
@@ -563,7 +594,9 @@ Request:
 Response:
 
 ```clj
-{:type (eq "add_ok"), {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "add_ok"),
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 
@@ -582,7 +615,10 @@ Request:
 Response:
 
 ```clj
-{:type (eq "read_ok"), :value Int, {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "read_ok"),
+ :value Int,
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 
@@ -674,7 +710,7 @@ Response:
  [(either
    [(one (eq "r") "f") (one Any "k") (one [Any] "v")]
    [(one (eq "append") "f") (one Any "k") (one Any "v")])],
- {:k :msg_id} Int,
+ #schema.core.OptionalKey{:k :msg_id} Int,
  :in_reply_to Int}
 ```
 
@@ -770,7 +806,7 @@ Response:
  [(either
    [(one (eq "r") "f") (one Any "k") (one Any "v")]
    [(one (eq "w") "f") (one Any "k") (one Any "v")])],
- {:k :msg_id} Int,
+ #schema.core.OptionalKey{:k :msg_id} Int,
  :in_reply_to Int}
 ```
 
@@ -815,7 +851,10 @@ Request:
 Response:
 
 ```clj
-{:type (eq "generate_ok"), :id Any, {:k :msg_id} Int, :in_reply_to Int}
+{:type (eq "generate_ok"),
+ :id Any,
+ #schema.core.OptionalKey{:k :msg_id} Int,
+ :in_reply_to Int}
 ```
 
 

--- a/doc/workloads.md
+++ b/doc/workloads.md
@@ -27,6 +27,7 @@ messages that you'll need to handle.
 - [G-set](#workload-g-set)
 - [Kafka](#workload-kafka)
 - [Lin-kv](#workload-lin-kv)
+- [Lin-kv-reconfig](#workload-lin-kv-reconfig)
 - [Pn-counter](#workload-pn-counter)
 - [Txn-list-append](#workload-txn-list-append)
 - [Txn-rw-register](#workload-txn-rw-register)
@@ -55,9 +56,7 @@ Request:
 Response:
 
 ```clj
-{:type (eq "topology_ok"),
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "topology_ok"), {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 
@@ -75,9 +74,7 @@ Request:
 Response:
 
 ```clj
-{:type (eq "broadcast_ok"),
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "broadcast_ok"), {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 
@@ -96,7 +93,7 @@ Response:
 ```clj
 {:type (eq "read_ok"),
  :messages [Any],
- #schema.core.OptionalKey{:k :msg_id} Int,
+ {:k :msg_id} Int,
  :in_reply_to Int}
 ```
 
@@ -122,10 +119,7 @@ Request:
 Response:
 
 ```clj
-{:type (eq "echo_ok"),
- :echo Any,
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "echo_ok"), :echo Any, {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 
@@ -152,9 +146,7 @@ Request:
 Response:
 
 ```clj
-{:type (eq "add_ok"),
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "add_ok"), {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 
@@ -173,10 +165,7 @@ Request:
 Response:
 
 ```clj
-{:type (eq "read_ok"),
- :value Int,
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "read_ok"), :value Int, {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 
@@ -200,9 +189,7 @@ Request:
 Response:
 
 ```clj
-{:type (eq "add_ok"),
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "add_ok"), {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 
@@ -221,10 +208,7 @@ Request:
 Response:
 
 ```clj
-{:type (eq "read_ok"),
- :value [Any],
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "read_ok"), :value [Any], {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 
@@ -322,7 +306,7 @@ Response:
 ```clj
 {:type (eq "send_ok"),
  :offset (named Int "offset"),
- #schema.core.OptionalKey{:k :msg_id} Int,
+ {:k :msg_id} Int,
  :in_reply_to Int}
 ```
 
@@ -368,13 +352,9 @@ Response:
 {:type (eq "poll_ok"),
  :msgs
  {(named Str "key")
-  [[#schema.core.One{:schema (named Int "offset"),
-                     :optional? false,
-                     :name "offset"}
-    #schema.core.One{:schema (named Any "msg"),
-                     :optional? false,
-                     :name "msg"}]]},
- #schema.core.OptionalKey{:k :msg_id} Int,
+  [[{:schema (named Int "offset"), :optional? false, :name "offset"}
+    {:schema (named Any "msg"), :optional? false, :name "msg"}]]},
+ {:k :msg_id} Int,
  :in_reply_to Int}
 ```
 
@@ -405,9 +385,7 @@ Request:
 Response:
 
 ```clj
-{:type (eq "commit_offsets_ok"),
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "commit_offsets_ok"), {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 
@@ -431,7 +409,7 @@ Response:
 ```clj
 {:type (eq "list_committed_offsets_ok"),
  :offsets {(named Str "key") (named Int "offset")},
- #schema.core.OptionalKey{:k :msg_id} Int,
+ {:k :msg_id} Int,
  :in_reply_to Int}
 ```
 
@@ -456,17 +434,14 @@ Request:
 Response:
 
 ```clj
-{:type (eq "read_ok"),
- :value Any,
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "read_ok"), :value Any, {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 
 ### RPC: Write! 
 
 Blindly overwrites the value of a key. Creates keys if they do not presently
-exist. Servers should respond with a `write_ok` response once the write is
+exist. Servers should respond with a `read_ok` response once the write is
 complete. 
 
 Request:
@@ -478,9 +453,7 @@ Request:
 Response:
 
 ```clj
-{:type (eq "write_ok"),
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "write_ok"), {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 
@@ -499,9 +472,71 @@ Request:
 Response:
 
 ```clj
-{:type (eq "cas_ok"),
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "cas_ok"), {:k :msg_id} Int, :in_reply_to Int}
+```
+
+
+
+## Workload: Lin-kv-reconfig 
+
+A workload for a linearizable key-value store with dynamic cluster
+membership reconfiguration. Extends lin-kv by sending add_member and
+remove_member RPCs to change the cluster membership during the test.
+
+All nodes are spawned at startup, but only a subset are initial members.
+The init message includes an `initial_member_ids` field so nodes know
+whether they should participate in consensus from the start. Non-member
+nodes wait for an `add_member` command before joining.
+
+Maelstrom randomly picks nodes to add or remove without tracking actual
+membership state. The SUT is responsible for:
+- Treating add/remove of already-added/removed nodes as a no-op or error
+- Rejecting removes that would reduce the cluster below a viable size
+- Rejecting concurrent reconfigurations (e.g. Raft single-change rule)
+
+If a node is not a member, it returns error code 40 (:not-a-member) for
+KV operations, which is a definite failure. The linearizability checker
+treats these as operations that did not happen. 
+
+### RPC: Add-member! 
+
+Adds a node to the cluster. Sent to any node, which should propose the
+membership change to the cluster (or forward to the leader). The target
+node should begin participating in consensus once the membership change
+commits. If the node is already a member, the server may treat this as a
+no-op success or return an error. 
+
+Request:
+
+```clj
+{:type (eq "add_member"), :node_id java.lang.String, :msg_id Int}
+```
+
+Response:
+
+```clj
+{:type (eq "add_member_ok"), {:k :msg_id} Int, :in_reply_to Int}
+```
+
+
+### RPC: Remove-member! 
+
+Removes a node from the cluster. Sent to any node, which should propose
+the membership change to the cluster (or forward to the leader). The
+target node should stop participating in consensus once the membership
+change commits. If the node is already not a member, the server may treat
+this as a no-op success or return an error. 
+
+Request:
+
+```clj
+{:type (eq "remove_member"), :node_id java.lang.String, :msg_id Int}
+```
+
+Response:
+
+```clj
+{:type (eq "remove_member_ok"), {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 
@@ -528,9 +563,7 @@ Request:
 Response:
 
 ```clj
-{:type (eq "add_ok"),
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "add_ok"), {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 
@@ -549,10 +582,7 @@ Request:
 Response:
 
 ```clj
-{:type (eq "read_ok"),
- :value Int,
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "read_ok"), :value Int, {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 
@@ -644,7 +674,7 @@ Response:
  [(either
    [(one (eq "r") "f") (one Any "k") (one [Any] "v")]
    [(one (eq "append") "f") (one Any "k") (one Any "v")])],
- #schema.core.OptionalKey{:k :msg_id} Int,
+ {:k :msg_id} Int,
  :in_reply_to Int}
 ```
 
@@ -740,7 +770,7 @@ Response:
  [(either
    [(one (eq "r") "f") (one Any "k") (one Any "v")]
    [(one (eq "w") "f") (one Any "k") (one Any "v")])],
- #schema.core.OptionalKey{:k :msg_id} Int,
+ {:k :msg_id} Int,
  :in_reply_to Int}
 ```
 
@@ -785,10 +815,7 @@ Request:
 Response:
 
 ```clj
-{:type (eq "generate_ok"),
- :id Any,
- #schema.core.OptionalKey{:k :msg_id} Int,
- :in_reply_to Int}
+{:type (eq "generate_ok"), :id Any, {:k :msg_id} Int, :in_reply_to Int}
 ```
 
 

--- a/resources/errors.edn
+++ b/resources/errors.edn
@@ -41,4 +41,8 @@
   :name      :txn-conflict
   :definite? true
   :doc       "The requested transaction has been aborted because of a conflict with another transaction. Servers need not return this error on every conflict: they may choose to retry automatically instead."}
+ {:code      40
+  :name      :not-a-member
+  :definite? true
+  :doc       "The node is not currently a member of the cluster, and therefore cannot process the request. Used by the lin-kv-reconfig workload, where cluster membership changes dynamically via add_member and remove_member RPCs."}
  ]

--- a/src/maelstrom/core.clj
+++ b/src/maelstrom/core.clj
@@ -20,6 +20,7 @@
                                 [g-counter :as g-counter]
                                 [pn-counter :as pn-counter]
                                 [lin-kv :as lin-kv]
+                                [lin-kv-reconfig :as lin-kv-reconfig]
                                 [txn-list-append :as txn-list-append]
                                 [txn-rw-register :as txn-rw-register]
                                 [unique-ids :as unique-ids]]
@@ -42,6 +43,7 @@
    :g-counter       g-counter/workload
    :pn-counter      pn-counter/workload
    :lin-kv          lin-kv/workload
+   :lin-kv-reconfig lin-kv-reconfig/workload
    :txn-list-append txn-list-append/workload
    :txn-rw-register txn-rw-register/workload
    :unique-ids      unique-ids/workload})
@@ -80,7 +82,7 @@
                     generator)]
     (merge tests/noop-test
            opts
-           (dissoc workload :final-generator)
+           (dissoc workload :final-generator :stats-checker)
            {:name    (str (name workload-name))
             :nodes   nodes
             :ssh     {:dummy? true}
@@ -93,8 +95,9 @@
                                       {:nemeses (:perf nemesis-package)})
                         :timeline   (timeline/html)
                         :exceptions (checker/unhandled-exceptions)
-                        :stats      (-> (checker/stats)
-                                        jepsen.kafka/stats-checker)
+                        :stats      (or (:stats-checker workload)
+                                        (-> (checker/stats)
+                                            jepsen.kafka/stats-checker))
                         :availability (availability-checker)
                         :net        (net.checker/checker)
                         :workload   (:checker workload)})
@@ -163,6 +166,11 @@
                 (map keyword (str/split s #"\s+,\s+")))
     :validate [(partial every? cm/friendly-model-name)
                (cli/one-of (sort (map cm/friendly-model-name cm/all-models)))]]
+
+   [nil "--initial-member-count INT" "For the lin-kv-reconfig workload, how many nodes are initial cluster members."
+    :default 3
+    :parse-fn parse-long
+    :validate [pos? "must be positive"]]
 
    [nil "--key-count INT" "For the append test, how many keys should we test at once?"
     :parse-fn parse-long

--- a/src/maelstrom/db.clj
+++ b/src/maelstrom/db.clj
@@ -48,9 +48,10 @@
             (let [res (client/rpc!
                         client
                         node-id
-                        {:type "init"
-                         :node_id node-id
-                         :node_ids (:nodes test)}
+                        (merge {:type "init"
+                                :node_id node-id
+                                :node_ids (:nodes test)}
+                               (:init-extra test))
                         10000)]
               (when (not= "init_ok" (:type res))
                 (throw+ {:type      :init-failed

--- a/src/maelstrom/workload/lin_kv_reconfig.clj
+++ b/src/maelstrom/workload/lin_kv_reconfig.clj
@@ -1,0 +1,191 @@
+(ns maelstrom.workload.lin-kv-reconfig
+  "A workload for a linearizable key-value store with dynamic cluster
+  membership reconfiguration. Extends lin-kv by sending add_member and
+  remove_member RPCs to change the cluster membership during the test.
+
+  All nodes are spawned at startup, but only a subset are initial members.
+  The init message includes an `initial_member_ids` field so nodes know
+  whether they should participate in consensus from the start. Non-member
+  nodes wait for an `add_member` command before joining.
+
+  Maelstrom randomly picks nodes to add or remove without tracking actual
+  membership state. The SUT is responsible for:
+    - Treating add/remove of already-added/removed nodes as a no-op or error
+    - Rejecting removes that would reduce the cluster below a viable size
+    - Rejecting concurrent reconfigurations (e.g. Raft single-change rule)
+
+  If a node is not a member, it returns error code 40 (:not-a-member) for
+  KV operations, which is a definite failure. The linearizability checker
+  treats these as operations that did not happen."
+  (:require [maelstrom [client :as c]
+                       [net :as net]]
+            [maelstrom.workload.lin-kv :as lin-kv]
+            [jepsen [checker :as checker]
+                    [client :as client]
+                    [generator :as gen]
+                    [history :as history]
+                    [independent :as independent]]
+            [jepsen.tests.linearizable-register :as lin-reg]
+            [schema.core :as s]))
+
+;; New RPCs for membership changes
+
+(c/defrpc add-member!
+  "Adds a node to the cluster. Sent to any node, which should propose the
+  membership change to the cluster (or forward to the leader). The target
+  node should begin participating in consensus once the membership change
+  commits. If the node is already a member, the server may treat this as a
+  no-op success or return an error."
+  {:type    (s/eq "add_member")
+   :node_id s/Str}
+  {:type    (s/eq "add_member_ok")})
+
+(c/defrpc remove-member!
+  "Removes a node from the cluster. Sent to any node, which should propose
+  the membership change to the cluster (or forward to the leader). The
+  target node should stop participating in consensus once the membership
+  change commits. If the node is already not a member, the server may treat
+  this as a no-op success or return an error."
+  {:type    (s/eq "remove_member")
+   :node_id s/Str}
+  {:type    (s/eq "remove_member_ok")})
+
+;; Client
+
+(defn client
+  "Constructs a client for the lin-kv-reconfig workload."
+  ([net all-nodes]
+   (client net all-nodes nil nil))
+  ([net all-nodes conn node]
+   (reify client/Client
+     (open! [this test node]
+       (client net all-nodes (c/open! net) node))
+
+     (setup! [this test])
+
+     (invoke! [_ test op]
+       (let [timeout (max (* 10 (:mean (:latency test))) 1000)]
+         (case (:f op)
+           ;; KV operations - same as lin-kv
+           (:read :write :cas)
+           (c/with-errors op #{:read}
+             (let [[k v] (:value op)]
+               (case (:f op)
+                 :read  (let [v (:value (lin-kv/read conn node {:key k} timeout))]
+                          (assoc op
+                                 :type  :ok
+                                 :value (independent/tuple k v)))
+                 :write (do (lin-kv/write! conn node {:key k, :value v} timeout)
+                            (assoc op :type :ok))
+                 :cas   (let [[v v'] v]
+                          (lin-kv/cas! conn node {:key k, :from v, :to v'} timeout)
+                          (assoc op :type :ok)))))
+
+           ;; Membership changes - send to a random node
+           :add-member
+           (c/with-errors op #{}
+             (let [target (rand-nth all-nodes)]
+               (add-member! conn target {:node_id (:value op)} timeout)
+               (assoc op :type :ok)))
+
+           :remove-member
+           (c/with-errors op #{}
+             (let [target (rand-nth all-nodes)]
+               (remove-member! conn target {:node_id (:value op)} timeout)
+               (assoc op :type :ok))))))
+
+     (teardown! [_ test])
+
+     (close! [_ test]
+       (c/close! conn))
+
+     client/Reusable
+     (reusable? [this test]
+       true))))
+
+;; Generator
+
+(defn reconfig-op
+  "Generates a random reconfiguration operation for one of the given nodes."
+  [all-nodes]
+  (let [target (rand-nth all-nodes)]
+    (if (< (rand) 0.5)
+      {:type :invoke, :f :add-member,    :value target}
+      {:type :invoke, :f :remove-member, :value target})))
+
+(defn mixed-generator
+  "Wraps a KV operation generator, occasionally producing membership change
+  operations with the given probability (reconfig-fraction, e.g. 0.05 = 5%)."
+  [kv-gen all-nodes reconfig-fraction]
+  (reify gen/Generator
+    (op [this test ctx]
+      (if (< (rand) reconfig-fraction)
+        ;; Produce a reconfig op
+        (let [op (gen/fill-in-op (reconfig-op all-nodes) ctx)]
+          (if (= op :pending)
+            :pending
+            [op this]))
+        ;; Produce a KV op
+        (when-let [[op gen'] (gen/op kv-gen test ctx)]
+          [op (mixed-generator gen' all-nodes reconfig-fraction)])))
+
+    (update [this test ctx event]
+      (if (#{:add-member :remove-member} (:f event))
+        ;; Don't forward reconfig events to the KV generator
+        this
+        (mixed-generator (gen/update kv-gen test ctx event)
+                         all-nodes reconfig-fraction)))))
+
+;; Checker
+
+(defn reconfig-checker
+  "Wraps a checker, filtering out membership change operations from the
+  history before delegating to the base checker."
+  [base-checker]
+  (reify checker/Checker
+    (check [this test history opts]
+      (let [kv-history (->> history
+                            (remove #(#{:add-member :remove-member} (:f %)))
+                            vec
+                            history/history)]
+        (checker/check base-checker test kv-history opts)))))
+
+(defn reconfig-stats-checker
+  "Wraps a stats checker so that :add-member and :remove-member ops don't
+  cause the overall stats to be invalid when they have no successes."
+  ([]
+   (reconfig-stats-checker (checker/stats)))
+  ([c]
+   (reify checker/Checker
+     (check [this test history opts]
+       (let [res (checker/check c test history opts)]
+         (if (every? :valid? (vals (dissoc (:by-f res)
+                                           :add-member :remove-member)))
+           (assoc res :valid? true)
+           res))))))
+
+;; Workload
+
+(defn workload
+  "Constructs a workload for a linearizable key-value store with dynamic
+  membership reconfiguration.
+
+      {:net     A Maelstrom network
+       :nodes   All node IDs}
+
+  The initial cluster starts with initial-member-count (default 3) nodes.
+  Remaining nodes are non-members until they receive an add_member command."
+  [opts]
+  (let [all-nodes       (:nodes opts)
+        node-count      (count all-nodes)
+        initial-count   (min (get opts :initial-member-count 3)
+                             node-count)
+        initial-members (vec (take initial-count all-nodes))
+        base            (lin-reg/test {:nodes all-nodes})]
+    (assoc base
+           :client        (client (:net opts) all-nodes)
+           :generator     (mixed-generator (:generator base) all-nodes 0.05)
+           :checker       (reconfig-checker (:checker base))
+           :stats-checker (-> (checker/stats)
+                              reconfig-stats-checker)
+           :init-extra    {:initial_member_ids initial-members})))


### PR DESCRIPTION
New workload that extends lin-kv with add_member and remove_member RPCs, allowing cluster membership to change during the test while verifying linearizability. Includes error code 40 (not-a-member) for nodes that are not currently cluster members.

The Python Raft demo is updated to support reconfiguration with the correct Raft thesis single-server membership change bug fix: a no-op is appended on leader election, and config changes are rejected until an entry in the current term is committed.