### PR TITLE
Add kill and pause nemesis faults

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ To make tests more or less aggressive, use:
 - `--latency MILLIS`: Approximate simulated network latency, during normal
   operations.
 - `--latency-dist DIST`: What latency distribution should Maelstrom use?
-- `--nemesis FAULT_TYPE`: A comma-separated list of faults to inject
+- `--nemesis FAULT_TYPE`: A comma-separated list of faults to inject. Options
+  are `partition` (network partitions), `kill` (kill and restart nodes), and
+  `pause` (suspend and resume node processes).
 - `--nemesis-interval SECONDS`: How long between nemesis operations, on average
 
 For broadcast tests, try

--- a/src/maelstrom/core.clj
+++ b/src/maelstrom/core.clj
@@ -48,7 +48,7 @@
 
 (def nemeses
   "A set of valid nemeses you can pass at the CLI."
-  #{:partition})
+  #{:partition :kill :pause})
 
 (defn maelstrom-test
   "Construct a Jepsen test from parsed CLI options"
@@ -203,7 +203,7 @@
     :parse-fn parse-long
     :validate [pos? "Must be positive."]]
 
-   [nil "--nemesis FAULTS" "A comma-separated list of faults to inject. The only fault currently is `partition`, which causes randomized network partitions between cluster nodes."
+   [nil "--nemesis FAULTS" "A comma-separated list of faults to inject. Options are `partition`, which causes randomized network partitions between cluster nodes; `kill`, which kills and restarts random nodes; and `pause`, which suspends and resumes random nodes' processes."
     :default #{}
     :parse-fn (fn [string]
                 (->> (str/split string #"\s*,\s*")

--- a/src/maelstrom/db.clj
+++ b/src/maelstrom/db.clj
@@ -10,6 +10,57 @@
                        [service :as service]]
             [slingshot.slingshot :refer [try+ throw+]]))
 
+(defn init-node!
+  "Sends an init message to a freshly-started node, blocking until it
+  acknowledges. Throws if the node fails to initialize."
+  [net test node-id]
+  (let [client (client/open! net)]
+    (try+
+      (let [res (client/rpc!
+                  client
+                  node-id
+                  {:type "init"
+                   :node_id node-id
+                   :node_ids (:nodes test)}
+                  10000)]
+        (when (not= "init_ok" (:type res))
+          (throw+ {:type      :init-failed
+                   :node      node-id
+                   :response  res}
+                  nil
+                  (str "Expected an init_ok message, but node responded with "
+                       (pr-str res)))))
+      (catch [:type :maelstrom.client/timeout] e
+        (throw+ {:type :init-failed
+                 :node node-id}
+                (:throwable &throw-context)
+                (str "Expected node " node-id
+                     " to respond to an init message, but node did not respond.")))
+      (finally
+        (client/close! client)))))
+
+(defn start-node!
+  "Starts a node's process (unless it is already running), registers it in the
+  `processes` atom, and initializes it. `append?` controls whether the node's
+  log file is appended to (on restart) or truncated (on first start). Safe to
+  call on an already-running node, in which case it does nothing."
+  [opts net processes test node-id append?]
+  (when-not (get @processes node-id)
+    (info "Setting up" node-id)
+    (swap! processes assoc node-id
+           (process/start-node!
+             {:node-id  node-id
+              :bin      (:bin opts)
+              :args     (:args opts)
+              :net      net
+              :dir      (System/getProperty "java.io.tmpdir")
+              :log-stderr? (:log-stderr test)
+              :append?  append?
+              :log-file (->> (str node-id ".log")
+                             (store/path test "node-logs")
+                             .getCanonicalPath)}))
+    (init-node! net test node-id)))
+
 (defn db
   "Options:
 
@@ -28,45 +79,8 @@
                              net
                              (service/default-services test))))
 
-        ; Start this node
-        (info "Setting up" node-id)
-        (swap! processes assoc node-id
-               (process/start-node!
-                 {:node-id  node-id
-                  :bin      (:bin opts)
-                  :args     (:args opts)
-                  :net      net
-                  :dir      (System/getProperty "java.io.tmpdir")
-                  :log-stderr? (:log-stderr test)
-                  :log-file (->> (str node-id ".log")
-                                 (store/path test "node-logs")
-                                 .getCanonicalPath)}))
-
-        ; Initialize this node
-        (let [client (client/open! net)]
-          (try+
-            (let [res (client/rpc!
-                        client
-                        node-id
-                        {:type "init"
-                         :node_id node-id
-                         :node_ids (:nodes test)}
-                        10000)]
-              (when (not= "init_ok" (:type res))
-                (throw+ {:type      :init-failed
-                         :node      node-id
-                         :response  res}
-                        nil
-                        (str "Expected an init_ok message, but node responded with "
-                             (pr-str res)))))
-            (catch [:type :maelstrom.client/timeout] e
-              (throw+ {:type :init-failed
-                       :node node-id}
-                      (:throwable &throw-context)
-                      (str "Expected node " node-id
-                           " to respond to an init message, but node did not respond.")))
-            (finally
-              (client/close! client)))))
+        ; Start and initialize this node
+        (start-node! opts net processes test node-id false))
 
       (teardown! [_ test node]
         ; Tear down node
@@ -79,4 +93,38 @@
         (when (= node (jepsen/primary test))
           (when-let [s @services]
             (service/stop-services! s)
-            (reset! services nil)))))))
+            (reset! services nil))))
+
+      ; Kill/start and pause/resume return short, serializable status keywords:
+      ; the nemesis records them in the history, so they must not leak process
+      ; maps (which hold unserializable objects like java.lang.Process).
+      db/Kill
+      (kill! [_ test node]
+        (if-let [p (get @processes node)]
+          (do (info "Killing" node)
+              (process/kill-node! p)
+              (swap! processes dissoc node)
+              :killed)
+          :not-running))
+
+      (start! [_ test node]
+        ; Restart a previously-killed node, appending to its existing log.
+        (if (get @processes node)
+          :already-running
+          (do (start-node! opts net processes test node true)
+              :started)))
+
+      db/Pause
+      (pause! [_ test node]
+        (if-let [p (get @processes node)]
+          (do (info "Pausing" node)
+              (process/pause-node! p)
+              :paused)
+          :not-running))
+
+      (resume! [_ test node]
+        (if-let [p (get @processes node)]
+          (do (info "Resuming" node)
+              (process/resume-node! p)
+              :resumed)
+          :not-running)))))

--- a/src/maelstrom/process.clj
+++ b/src/maelstrom/process.clj
@@ -4,6 +4,7 @@
             [clojure [pprint :refer [pprint]]
                      [string :as str]]
             [clojure.java.io :as io]
+            [clojure.java.shell :refer [sh]]
             [clojure.tools.logging :refer [info warn]]
             [byte-streams :as bs]
             [cheshire.core :as json]
@@ -173,6 +174,7 @@
       :args         A list of arguments to the program
       :node-id      This node's ID
       :log-file     A string file to receive stderr output
+      :append?      Whether to append to (rather than truncate) the log file
       :net          A network.
       :log-stderr?  Whether to log stderr output from processes to our logger
 
@@ -190,7 +192,7 @@
         net     (:net opts)
         _       (net/add-node! net node-id)
         _       (io/make-parents (:log-file opts))
-        log     (io/writer (:log-file opts))
+        log     (io/writer (:log-file opts) :append (boolean (:append? opts)))
         bin     (.getCanonicalPath (io/file (:bin opts)))
         process (-> (ProcessBuilder. ^java.util.List (cons bin (:args opts)))
                     (.directory (io/file (:dir opts)))
@@ -254,3 +256,38 @@
      :stdin       @stdin-thread
      :stderr      @stderr-thread
      :stdout      @stdout-thread}))
+
+(defn kill-node!
+  "Forcibly kills a node's process for fault injection, and shuts down its IO
+  threads. Unlike `stop-node!`, this leaves the node registered in the network
+  (so peers can still address it; their messages simply pile up undelivered
+  until the node is restarted) and does not throw if the process has already
+  exited."
+  [{:keys [^Process process running? ^Writer log
+           stdin-thread stderr-thread stdout-thread]}]
+  (when (.isAlive process)
+    (.. process destroyForcibly (waitFor 5 TimeUnit/SECONDS)))
+
+  ; Shut down workers
+  (reset! running? false)
+  (mapv deref [stdin-thread stderr-thread stdout-thread])
+
+  ; Close log writer
+  (.close log))
+
+(defn signal-node!
+  "Sends a Unix signal (e.g. \"STOP\", \"CONT\") to a node's OS process. No-op if
+  the process has already exited."
+  [{:keys [^Process process]} signal]
+  (when (.isAlive process)
+    (sh "kill" (str "-" signal) (str (.pid process)))))
+
+(defn pause-node!
+  "Pauses a node's process by sending it SIGSTOP."
+  [node]
+  (signal-node! node "STOP"))
+
+(defn resume-node!
+  "Resumes a paused node's process by sending it SIGCONT."
+  [node]
+  (signal-node! node "CONT"))


### PR DESCRIPTION
`--nemesis` only supported `partition`. This adds `kill`, which kills and restarts nodes, and `pause`, which suspends and resumes them with SIGSTOP/SIGCONT.

Most of the plumbing was already in place: `maelstrom.nemesis/package` composes `jepsen.nemesis.combined/db-package`, which gates itself on the `:faults` set. It just needed the DB to implement `jepsen.db/Kill` and `jepsen.db/Pause`, plus a CLI change to accept the new faults.

A few notes on the implementation:

Killing a node doesn't unregister it from the network. `net/send!` throws `::node-not-found` on unknown destinations, so removing a dead node would blow up the stdout thread of every peer still trying to talk to it. Its queue stays put instead, messages pile up undelivered, and the restart installs a fresh one.

Restarting re-sends `init`, since nodes hold state only in memory. So `kill` wipes a node's state, which is rather the point, but it will break workloads that assume durability.

`start!` and `resume!` are idempotent, because the flip-flop generator calls them on `:all` nodes, not just the ones it took down.

The four protocol methods return keywords rather than anything larger. The nemesis writes their return value into the history, and handing it a process map crashes the Fressian writer.

`pause` is Unix-only. The JVM can't suspend a process portably, only kill it.

Tested against `demo/ruby/g_set.rb` on three nodes. `pause` stays valid; `kill` loses elements, as you'd expect once nodes exit 137 and come back empty; `partition,kill,pause` compose. Under `pause` the demo does occasionally report one lost element, when an add lands on a paused node right at the time limit and gossip hasn't converged before the final reads.
