### PR TITLE
Bound down nodes' message queues and redeliver backlog on restart

### DIFF
--- a/src/maelstrom/db.clj
+++ b/src/maelstrom/db.clj
@@ -47,19 +47,30 @@
   [opts net processes test node-id append?]
   (when-not (get @processes node-id)
     (info "Setting up" node-id)
-    (swap! processes assoc node-id
-           (process/start-node!
-             {:node-id  node-id
-              :bin      (:bin opts)
-              :args     (:args opts)
-              :net      net
-              :dir      (System/getProperty "java.io.tmpdir")
-              :log-stderr? (:log-stderr test)
-              :append?  append?
-              :log-file (->> (str node-id ".log")
-                             (store/path test "node-logs")
-                             .getCanonicalPath)}))
-    (init-node! net test node-id)))
+    ; On a restart, snapshot whatever queued up for the node while it was down.
+    ; `start-node!` below installs a fresh queue, so init is delivered first;
+    ; we redeliver the backlog once the node is up. On initial setup the node
+    ; has no queue yet and this is nil.
+    (let [backlog (net/drain-queue! net node-id)]
+      (swap! processes assoc node-id
+             (process/start-node!
+               {:node-id  node-id
+                :bin      (:bin opts)
+                :args     (:args opts)
+                :net      net
+                :dir      (System/getProperty "java.io.tmpdir")
+                :log-stderr? (:log-stderr test)
+                :append?  append?
+                :log-file (->> (str node-id ".log")
+                               (store/path test "node-logs")
+                               .getCanonicalPath)}))
+      (net/up! net node-id)
+      (init-node! net test node-id)
+      ; The restarted node now receives the messages peers sent to the previous
+      ; instance, as it would if it came back up on the same address.
+      (when (seq backlog)
+        (info "Redelivering" (count backlog) "buffered message(s) to" node-id)
+        (net/requeue! net node-id backlog)))))
 
 (defn db
   "Options:
@@ -102,6 +113,7 @@
       (kill! [_ test node]
         (if-let [p (get @processes node)]
           (do (info "Killing" node)
+              (net/down! net node)
               (process/kill-node! p)
               (swap! processes dissoc node)
               :killed)
@@ -118,6 +130,7 @@
       (pause! [_ test node]
         (if-let [p (get @processes node)]
           (do (info "Pausing" node)
+              (net/down! net node)
               (process/pause-node! p)
               :paused)
           :not-running))
@@ -126,5 +139,6 @@
         (if-let [p (get @processes node)]
           (do (info "Resuming" node)
               (process/resume-node! p)
+              (net/up! net node)
               :resumed)
           :not-running)))))

--- a/src/maelstrom/net.clj
+++ b/src/maelstrom/net.clj
@@ -99,6 +99,7 @@
          :latency-dist    (latency-dist latency)
          :p-loss          0
          :partitions      {}
+         :down-nodes      #{}
          :next-client-id  -1
          :next-message-id (atom -1)}))
 
@@ -151,6 +152,20 @@
   (swap! net update :queues dissoc node-id)
   net)
 
+(defn down!
+  "Marks a node as down (killed or paused). While a node is down, messages
+  sent to it are dropped once its queue reaches max-queue-size."
+  [net node-id]
+  (swap! net update :down-nodes conj node-id)
+  net)
+
+(defn up!
+  "Marks a node as up again, lifting the queue bound applied while it was
+  down."
+  [net node-id]
+  (swap! net update :down-nodes disj node-id)
+  net)
+
 (defn ^PriorityBlockingQueue queue-for
   "Returns the queue for a particular recipient node."
   [net node]
@@ -186,6 +201,16 @@
     0
     (long (draw (:latency-dist net)))))
 
+(def max-queue-size
+  "The maximum number of messages the network buffers for a node which is
+  currently down (killed or paused). A down node isn't draining its queue, so
+  once it holds this many messages, further messages destined for it are
+  dropped--a runaway backlog can't exhaust the heap and crash the test itself.
+  A node that recovers still receives up to this many of the messages sent
+  while it was down. Queues of running nodes are unbounded: under simulated
+  latency they legitimately hold (arrival rate * latency) messages."
+  10)
+
 (defn send!
   "Sends a message (either a map or Message) into the network. Message must
   contain :src and :dest keys, both node IDs. Generates an :id for the message.
@@ -216,8 +241,13 @@
       (let [src  (:src message)
             dest (:dest message)
             q    (queue-for net dest)]
-        (.put q {:deadline deadline
-                 :message  message})
+        ; A killed or paused node isn't draining its queue, so once it's full
+        ; we drop further messages rather than buffer an unbounded backlog.
+        ; Messages to running nodes are never dropped.
+        (when (or (not (contains? (:down-nodes n) dest))
+                  (< (.size q) max-queue-size))
+          (.put q {:deadline deadline
+                   :message  message}))
         net))))
 
 (defn recv!
@@ -245,3 +275,24 @@
 
             ; And deliver!
             message)))))
+
+(defn drain-queue!
+  "Removes and returns all buffered message envelopes for a node as a vector,
+  or nil if the node has no queue. Used to snapshot the backlog that piled up
+  for a killed node, so it can be redelivered once the node restarts."
+  [net node-id]
+  (when-let [^PriorityBlockingQueue q (-> @net :queues (get node-id))]
+    (let [drained (java.util.ArrayList.)]
+      (.drainTo q drained)
+      (vec drained))))
+
+(defn requeue!
+  "Re-inserts message envelopes (as produced by [[drain-queue!]]) into a node's
+  queue, capped at max-queue-size. Used to redeliver a restarted node's
+  backlog once it has initialized. Mutates and returns the network."
+  [net node-id envelopes]
+  (let [q (queue-for net node-id)]
+    (doseq [e envelopes]
+      (when (< (.size q) max-queue-size)
+        (.put q e))))
+  net)

--- a/test/maelstrom/net_test.clj
+++ b/test/maelstrom/net_test.clj
@@ -1,0 +1,90 @@
+(ns maelstrom.net-test
+  (:require [clojure [test :refer :all]]
+            [maelstrom [net :as net]]
+            [maelstrom.net.journal :as j]))
+
+; These tests drive the network directly, without a running test, so there's
+; no journal to write to.
+(use-fixtures :each
+  (fn [run-test]
+    (with-redefs [j/log-send! (fn [_ _])
+                  j/log-recv! (fn [_ _])]
+      (run-test))))
+
+(defn test-net
+  "A network with zero latency."
+  []
+  (net/net {:mean 0, :dist :constant} false false))
+
+(defn send-n!
+  "Sends n messages from src to dest, with bodies {:i 0} ... {:i n-1}."
+  [net src dest n]
+  (dotimes [i n]
+    (net/send! net {:src src, :dest dest, :body {:i i}})))
+
+(defn queue-size
+  [net node]
+  (.size (net/queue-for net node)))
+
+(defn recv-all!
+  "Receives every pending message for node; returns the set of their bodies'
+  :i values."
+  [net node]
+  (loop [is #{}]
+    (if-let [m (net/recv! net node 10)]
+      (recur (conj is (:i (:body m))))
+      is)))
+
+(deftest queue-bound-test
+  (let [n (test-net)]
+    (net/add-node! n "src")
+
+    (testing "running nodes have unbounded queues"
+      (net/add-node! n "running")
+      (send-n! n "src" "running" (* 2 net/max-queue-size))
+      (is (= (* 2 net/max-queue-size) (queue-size n "running"))))
+
+    (testing "down nodes drop messages beyond max-queue-size"
+      (net/add-node! n "down")
+      (net/down! n "down")
+      (send-n! n "src" "down" (* 3 net/max-queue-size))
+      (is (= net/max-queue-size (queue-size n "down"))))
+
+    (testing "coming back up lifts the bound"
+      (net/up! n "down")
+      (send-n! n "src" "down" 5)
+      (is (= (+ net/max-queue-size 5) (queue-size n "down"))))))
+
+(deftest pause-redelivery-test
+  ; A paused node keeps its queue. Messages sent while it's paused--up to
+  ; max-queue-size--must be received once it resumes.
+  (let [n (test-net)]
+    (net/add-node! n "src")
+    (net/add-node! n "n1")
+    (net/down! n "n1")                                  ; pause
+    (send-n! n "src" "n1" (* 2 net/max-queue-size))
+    (net/up! n "n1")                                    ; resume
+    (is (= (set (range net/max-queue-size))            ; oldest messages kept
+           (recv-all! n "n1")))))
+
+(deftest kill-restart-redelivery-test
+  ; Mirrors the restart sequence in maelstrom.db/start-node!: snapshot the
+  ; dead node's backlog, install a fresh queue, deliver init, then requeue
+  ; the backlog. The restarted node must see init first, then receive the
+  ; messages peers sent while it was dead.
+  (let [n (test-net)]
+    (net/add-node! n "src")
+    (net/add-node! n "n1")
+    (net/down! n "n1")                                  ; kill
+    (send-n! n "src" "n1" (* 2 net/max-queue-size))     ; peers keep sending
+    (let [backlog (net/drain-queue! n "n1")]
+      (is (= net/max-queue-size (count backlog)))
+      (net/add-node! n "n1")                            ; restart: fresh queue
+      (net/up! n "n1")
+      (net/send! n {:src "src", :dest "n1", :body {:type "init"}})
+      ; The node consumes init before anything else...
+      (is (= "init" (:type (:body (net/recv! n "n1" 10)))))
+      ; ... and once the backlog is requeued, receives the buffered messages.
+      (net/requeue! n "n1" backlog)
+      (is (= (set (range net/max-queue-size))
+             (recv-all! n "n1"))))))


### PR DESCRIPTION
Follows up on #102, addressing @aphyr's suggestion there.

Messages sent to a killed or paused node used to pile up without bound — enough to OOM the test itself on a long fault. The network now tracks which nodes are down (`kill!`/`pause!` mark them, `start!`/`resume!` clear them) and caps a down node's queue at `max-queue-size` (10), dropping messages beyond that, the same way packet loss drops them.

The bound has to be scoped to down nodes: messages wait out their simulated latency inside the destination queue, so a healthy queue legitimately holds about rate × latency messages. A global cap made a fault-free broadcast run at `--rate 100 --latency 100` drop ~23% of inter-server traffic and fail the checker; scoped to down nodes, the same run passes untouched.

A recovering node still sees up to `max-queue-size` of what it missed. A paused node gets that for free, since it resumes the same process and drains its backlog. A killed node restarts as a fresh process, so the backlog is snapshotted before the restart and requeued only after init — a node must never see messages before it learns its own id — while still modeling a new instance picking up messages meant for the old one.

`test/maelstrom/net_test.clj` pins the semantics: unbounded while up, capped while down, paused nodes receive their backlog on resume, and restarted nodes get init first, then the backlog. Also verified end-to-end with g_set and broadcast demos: no drops in fault-free runs, redelivery firing under a high-rate kill.
